### PR TITLE
Maximum meshsize is now per dielectric. Force gdspy version 1.6 or later

### DIFF
--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -1,4 +1,30 @@
+# Utilities for gds2palace 
+########################################################################
+#
+# Copyright 2025 Volker Muehlhaus and IHP PDK Authors
+#
+# Licensed under the GNU General Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
+
 import gds2palace.util_stackup_reader as stackup_reader
 import gds2palace.util_gds_reader as gds_reader
 import gds2palace.util_utilities as utilities
 import gds2palace.util_simulation_setup as simulation_setup
+
+__version__ = "1.0.0"   # version of gds2palace
+
+utilities.check_module_version("util_stackup_reader", "1.0.0")
+utilities.check_module_version("util_gds_reader", "1.0.0")
+utilities.check_module_version("util_utilities", "1.0.0")
+utilities.check_module_version("util_simulation_setup", "1.0.0")

--- a/workflow/gds2palace/util_gds_reader.py
+++ b/workflow/gds2palace/util_gds_reader.py
@@ -18,10 +18,25 @@
 
 # Extract objects on IHP layers in GDSII file
 
+__version__ = "1.0.0"
+
 import gdspy
 import numpy as np
 import os
 import gds2palace.util_stackup_reader as stackup_reader
+
+# check that we have gdspy version 1.6.x or later
+# gdspy 1.4.2 is known for issues with our geometries
+
+version_str = gdspy.__version__
+major, minor, patch = version_str.split('.')
+if int(major) == 1:
+  if int(minor) < 6:
+    print('\nERROR: Your gdspy module version ', version_str, ' is too old. Please update to 1.6.13 or later!')
+    print('Consider using venv if you are not allowed to modify the global Python modules of your system.')
+    print('https://docs.python.org/3/library/venv.html')
+    exit(1)
+
 
 
 # ============= technology specific stuff ===============

--- a/workflow/gds2palace/util_stackup_reader.py
+++ b/workflow/gds2palace/util_stackup_reader.py
@@ -23,7 +23,7 @@
 # Initial version 20 Nov 2024  Volker Muehlhaus 
 # Added support for sheet resistance 07 Oct 2025 Volker Muehlhaus 
 
-
+__version__ = "1.0.0"
 
 import os
 import xml.etree.ElementTree 
@@ -170,6 +170,10 @@ class metal_layer:
     # force to sheet if zero thickness
     if data.get("Zmin") == data.get("Zmax"):
       self.type = "SHEET"
+
+    if self.type == "SHEET" and not self.zmin==self.zmax:
+      print('ERROR: Layer ', self.name, ' is defined as sheet layer, but zmax is different from zmin. This is not valid!')
+      exit(1)
 
     self.thickness = self.zmax-self.zmin
     self.is_via = (self.type=="VIA")

--- a/workflow/gds2palace/util_utilities.py
+++ b/workflow/gds2palace/util_utilities.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os, tempfile, platform, sys
+import os, tempfile, platform, sys, importlib
 
+__version__ = "1.0.0"
 
 # ============================== filename and path  =================================
 
@@ -50,3 +51,11 @@ def create_run_script (destination_path):
     f.close()   
 
 
+def check_module_version(module_name, expected_version):
+    module = importlib.import_module(module_name)
+    version = getattr(module, "__version__", None)
+    if version is not None:
+        if getattr(module, "__version__", None) < expected_version:
+            raise RuntimeError(f"{module_name} version mismatch: expected {expected_version}, got {module.__version__}")
+    else:
+            raise RuntimeError(f"{module_name} does not provide version information, please update!")


### PR DESCRIPTION
Calculation of maximum meshsize is now per dielectric layer. Check for gdspy version 1.6 or later, because 1.4.2 causes issues. Add version information for gds2python module files. Palace solver setting changed to AdaptiveTol = 2e-2