### PR TITLE
Fix issue with non-sequential excitation

### DIFF
--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1122,7 +1122,7 @@ def create_palace (excite_ports, settings):
             excite_group = False
             for idx, group in enumerate(excite_ports):
                 if portnum in group:
-                    excite_group = idx + 1
+                    excite_group = portnum
 
             Palace_lumpedport['Index'] = portnum
             Palace_lumpedport['R'] = port.port_Z0


### PR DESCRIPTION
Previously, the port groups for active ports were created as 1,2,3 ... but this doesn't work. 
Palace wants port group number = port number. Fixed now. 

This PR fixes https://github.com/VolkerMuehlhaus/gds2palace_ihp_sg13g2/issues/9