### PR TITLE
Fix duplicate boundary surfaces causing MFEM STable3D abort (extends PR #11)

### DIFF
--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1230,9 +1230,20 @@ def create_model (excite_ports, settings):
 
     # 2D surfaces from shell of hollow conductors (top, bottom and side walls)
     # one physical group per polygon (shared by all polygon surfaces)
+    #
+    # Fix C: a fragmented surface tag can end up in MULTIPLE physical groups when:
+    #   (a) two polygons of the SAME layer share a fragment (touching pads), or
+    #   (b) two polygons of DIFFERENT layers touch directly (no dielectric gap
+    #       between them).
+    # MFEM v0.16 then aborts in STable3D::operator() because the boundary
+    # element appears twice with different attributes. We track the tags
+    # already claimed (globally across layers and polysurfaces) and skip
+    # subsequent claims so each surface ends up in exactly one physical
+    # group.
+    _claimed_surface_tags_global = set()  # introduced by Fix C
     for layername in metal_perpolytags_2D.keys():
         if len(metal_perpolytags_2D[layername]) > 0:
-            # surfaces used for planar metal 
+            # surfaces used for planar metal
 
             # gmsh
             all_phys_surfacetags_for_layer_xy = []
@@ -1250,12 +1261,19 @@ def create_model (excite_ports, settings):
 
                     new_tags_planar = []
                     new_tags_vertical = []
-                    
+
                     for tag in new_tags:
+                        if tag in _claimed_surface_tags_global:
+                            # Fix C: surface already claimed by another polysurface
+                            # (same layer different polygon, OR different layer that
+                            # touches this one). Skipping prevents the same boundary
+                            # element from being written under two physical groups.
+                            continue
+                        _claimed_surface_tags_global.add(tag)
                         if is_vertical_surface(tag):
                             new_tags_vertical.append(tag)
                         else:
-                            new_tags_planar.append(tag)     
+                            new_tags_planar.append(tag)
 
                     # xy in-plane
                     phys_group_xy = gmsh.model.addPhysicalGroup(2, new_tags_planar, tag=-1)
@@ -1723,6 +1741,15 @@ def create_model (excite_ports, settings):
     if not preview_only:
         # now generate mesh
         gmsh.model.mesh.generate(3)
+
+        # Post-mesh dedupe: PR #11 (removeAllDuplicates in add_metals)
+        # left the dielectric path uncovered (line ~553 commented because
+        # OCC-level dedupe broke oxide mappings). At mesh level the dedupe
+        # is safe (operates on mesh entities only) and removes the residual
+        # boundary duplicates that otherwise trigger MFEM STable3D abort
+        # in Palace v0.16.
+        gmsh.model.mesh.removeDuplicateNodes()
+        gmsh.model.mesh.removeDuplicateElements()
 
         # Save mesh
         gmsh.option.setNumber("Mesh.Binary", 0)


### PR DESCRIPTION
## Heads up

I'm not an EM-software expert — I'm using gds2palace for a research project and drafted this PR with help from coding agents. They read the code, formed the hypotheses and wrote the patch under my supervision; I ran the verification on my host. This is the smallest change I could justify that clears the abort signature reported in the companion issue without breaking the upstream `palace_line_viaport.py` example. I'm not claiming it's the canonical fix — happy for it to be refactored, consolidated with PR #11, or rejected for a different design.

## What's in here

This PR addresses bug #1 from issue #20 (the duplicate-boundary class). It extends PR #11 to two paths it didn't cover.

**Fix A — post-mesh dedupe.** After `gmsh.model.mesh.generate(3)` (around line 1725), call `removeDuplicateNodes()` and `removeDuplicateElements()`. This covers the dielectric path that PR #11 left out (line ~553 was commented because OCC-level dedupe was lossy for oxide mappings). At mesh level the dedupe is safe — it only touches mesh entities, the OCC oxide mapping is untouched.

**Fix C — global tag dedupe in the re-tagging loop.** In the loop at lines 1241-1268, introduce a set `_claimed_surface_tags_global` so each fragmented surface tag is assigned to exactly one physical group across all layers and polygons. Resolves the case where two polysurfaces share a fragment surface and both call `addPhysicalGroup` on the same elementary tag.

(Numbering: I have a hypothetical "Fix B" in `is_vertical_surface()` for degenerate-normal faces (`norm ≈ 0` → `[NaN,NaN,NaN]`, currently classified as planar by default). It didn't fire on my repro so I didn't ship it; the A/C labels survive in the patch comments for traceability with the issue thread.)

## What's NOT in here

The touching-conductor structural issue (bug #2 of the companion issue). After Fix A+C, a stack with two conductors sharing a z coordinate still aborts with a different signature (`(0,636,4151)`, vertex-0 sentinel) — that's a topology problem, not a duplicate problem, and needs a design call (skip the BC? merge domains? something else?). I left it for discussion in the issue.

## Verification

On my repro: duplicate 2D boundary elements drop from 1112 to 0 (counted via `gmsh.model.mesh.removeDuplicateElements()` on the saved `.msh`), and the original `MFEM STable3D (245,246,3198)` abort is gone.

On the upstream `palace_line_viaport.py` example (Metal1↔TopMetal2 via-port on `SG13G2_nosub.xml`): solves end-to-end with the patch applied — 1084 s wallclock, 755 K DOF, 41 frequency points, valid `port-S.csv`. So Fix A+C don't break the existing reference case.

On every run the gmsh log shows `Removing duplicate mesh nodes ... Found 0` and `Removing duplicate mesh elements ... Done`, confirming Fix A is wired in.

## Caveats

1. **Fix C is "first claim wins".** For two polygons of the *same* layer sharing a fragment, that's fine — same physical group either way. For two *different* layers sharing a fragment (touching conductors), the surface ends up tagged by whichever layer is iterated first. Strictly speaking that interface shouldn't be tagged as a one-sided boundary at all (it's internal) — but that's the bug #2 territory in the companion issue. Fix C here is the minimum that prevents the duplicate-tagging crash.

2. **Coverage.** I tested on my vertical-via repro (1112 → 0 dup elements), a denser geometry I haven't yet re-run with this exact patch but that showed the same dup pattern, and the upstream `palace_line_viaport.py` regression. If you have other reference cases that exercise this loop, I'd appreciate the heads up.

3. **Possible consolidation later.** PR #11 dedupes at OCC level inside `add_metals`. This PR adds dedupe at mesh level (post-`mesh.generate`) and at physical-group level (in the re-tagging loop). The three layers aren't redundant — they target different stages of the pipeline — but a future cleanup could probably collapse them. I didn't attempt it here to keep the diff minimal.

## Patch (inline, identical to `upstream_pr_gds2palace_v0.diff`)

```diff
diff --git a/workflow/gds2palace/util_simulation_setup.py b/workflow/gds2palace/util_simulation_setup.py
index 46c6d12..91c5e07 100644
--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1230,9 +1230,20 @@ def create_model (excite_ports, settings):
 
     # 2D surfaces from shell of hollow conductors (top, bottom and side walls)
     # one physical group per polygon (shared by all polygon surfaces)
+    #
+    # Fix C: a fragmented surface tag can end up in MULTIPLE physical groups when:
+    #   (a) two polygons of the SAME layer share a fragment (touching pads), or
+    #   (b) two polygons of DIFFERENT layers touch directly (no dielectric gap
+    #       between them).
+    # MFEM v0.16 then aborts in STable3D::operator() because the boundary
+    # element appears twice with different attributes. We track the tags
+    # already claimed (globally across layers and polysurfaces) and skip
+    # subsequent claims so each surface ends up in exactly one physical
+    # group.
+    _claimed_surface_tags_global = set()  # introduced by Fix C
     for layername in metal_perpolytags_2D.keys():
         if len(metal_perpolytags_2D[layername]) > 0:
-            # surfaces used for planar metal 
+            # surfaces used for planar metal
 
             # gmsh
             all_phys_surfacetags_for_layer_xy = []
@@ -1250,12 +1261,19 @@ def create_model (excite_ports, settings):
 
                     new_tags_planar = []
                     new_tags_vertical = []
-                    
+
                     for tag in new_tags:
+                        if tag in _claimed_surface_tags_global:
+                            # Fix C: surface already claimed by another polysurface
+                            # (same layer different polygon, OR different layer that
+                            # touches this one). Skipping prevents the same boundary
+                            # element from being written under two physical groups.
+                            continue
+                        _claimed_surface_tags_global.add(tag)
                         if is_vertical_surface(tag):
                             new_tags_vertical.append(tag)
                         else:
-                            new_tags_planar.append(tag)     
+                            new_tags_planar.append(tag)
 
                     # xy in-plane
                     phys_group_xy = gmsh.model.addPhysicalGroup(2, new_tags_planar, tag=-1)
@@ -1724,6 +1742,15 @@ def create_model (excite_ports, settings):
         # now generate mesh
         gmsh.model.mesh.generate(3)
 
+        # Post-mesh dedupe: PR #11 (removeAllDuplicates in add_metals)
+        # left the dielectric path uncovered (line ~553 commented because
+        # OCC-level dedupe broke oxide mappings). At mesh level the dedupe
+        # is safe (operates on mesh entities only) and removes the residual
+        # boundary duplicates that otherwise trigger MFEM STable3D abort
+        # in Palace v0.16.
+        gmsh.model.mesh.removeDuplicateNodes()
+        gmsh.model.mesh.removeDuplicateElements()
+
         # Save mesh
         gmsh.option.setNumber("Mesh.Binary", 0)
         gmsh.option.setNumber("Mesh.SaveAll", 0)  # value 1 means: save everything, no matter if in physical group or not - DON'T USE WITH V2.2
```