### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.3.6"   # version of gds2palace
+__version__ = "0.3.7"   # version of gds2palace
 

--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.3.7"   # version of gds2palace
+__version__ = "0.4.0"   # version of gds2palace
 


### PR DESCRIPTION
## Summary
- Bump `__version__` to `0.4.0` in `workflow/gds2palace/__init__.py`, matching the version just published to PyPI as [gds2palace 0.4.0](https://pypi.org/project/gds2palace/0.4.0/).

