### PR TITLE
AMR convergence metrics, Elmer thermal solver options, via/surface mesh fixes, dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ In addition to Palace that is required for simulation of the output files, these
 - matplotlib (for the inductor synthesis example scripts)
 - scikit-rf (for the script that converts Palace output to Touchstone SnP format)
 
+Two external tools are needed for parts of the workflow, but are not Python modules and must be installed separately:
+
+- [ParaView](https://www.paraview.org/) — to view field-dump output (Palace/Elmer EM) and Elmer thermal result files.
+- An MPI implementation — only needed for multi-process Elmer runs (`settings['ELMER_MPI_THREADS']`). Use OpenMPI or MPICH on Linux/macOS; on Windows, install [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi).
+
 Documentation assumes that you have created a Python venv named "palace" in ~/venv/palace and installed the modules there.
 
 ## Installing Palace

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,0 +1,1065 @@
+# gds2palace Architecture — a reference for AI agents
+
+This document exists to orient an AI coding agent quickly and *accurately* in this repository:
+what gds2palace actually is, what it is not, exactly how a model script talks to it, exactly what
+happens when you "run" a model (including the parts that live outside this repo entirely), and a
+worked analysis of the most structurally interesting example in the tree (inductor synthesis).
+
+It complements, rather than replaces, `doc/userguide_md_format/gds2palace_workflow_userguide.md`
+(the human-facing user guide — more screenshots, more narrative, less "trace the exact function
+calls"). Where the two disagree, trust the source code citations in this document; they were
+verified directly against the files at the time of writing, not inferred from the user guide's
+prose.
+
+**Repo root** for every path below: `D:\github-claude\gds2palace_ihp_sg13g2\` (GitHub:
+`VolkerMuehlhaus/gds2palace_ihp_sg13g2`, upstream of the `volkermuehlhaus-claude` fork this
+workspace develops under).
+
+---
+
+## 1. What gds2palace is, in one paragraph
+
+gds2palace is a pure Python toolkit that turns a GDSII layout plus an XML "stackup" file
+(metal/dielectric layer definitions, materials, via rules — specific to the IHP SG13G2 open-source
+RFIC PDK) into the input files for **AWS Palace**, a 3D FEM electromagnetic solver, or
+alternatively for **Elmer FEM**, a different open-source FEM solver. A model script — a short,
+hand-written (or AI-written, or setupEM-GUI-generated) Python file — imports `gds2palace`,
+describes a few simulation settings and a handful of ports, and calls one function
+(`simulation_setup.create_palace(...)` or `create_elmer(...)`). That call runs `gmsh` under the
+hood to build 3D geometry and mesh it, then writes out the solver's native input files. **Neither
+Palace nor Elmer is part of this package** — see §5.
+
+---
+
+## 2. Package layout — `workflow/gds2palace/`
+
+| File | Approx. size | Responsibility |
+|---|---|---|
+| `__init__.py` | 27 lines | Defines the entire public import surface (below) |
+| `util_stackup_reader.py` | ~1550 lines | Parses the XML technology stackup file |
+| `util_gds_reader.py` | ~600 lines | Parses the GDSII layout into polygon objects |
+| `util_simulation_setup.py` | **2694 lines** | The core engine: ports, gmsh geometry/mesh construction, Palace `config.json` writer, Elmer `.sif` writer |
+| `util_elmer.py` | ~600 lines | Elmer-specific file writers — internal, never imported directly by model scripts |
+| `util_utilities.py` | 146 lines | Path/filename helpers, the `run_sim`/`run_elmer` wrapper-script generators |
+
+`workflow/gds2palace/__init__.py` (full file, verified):
+
+```python
+from . import util_stackup_reader as stackup_reader
+from . import util_gds_reader as gds_reader
+from . import util_utilities as utilities
+from . import util_simulation_setup as simulation_setup
+
+__version__ = "0.4.1"   # version of gds2palace
+```
+
+So `from gds2palace import *` gives a model script exactly **four names**:
+`stackup_reader`, `gds_reader`, `utilities`, `simulation_setup`. `util_elmer` is *not*
+re-exported — it's an internal dependency of `util_simulation_setup.py`
+(`from . import util_elmer` at `util_simulation_setup.py:30`), never called directly from a model
+script.
+
+**PyPI package name is `gds2palace`, importable as `gds2palace`** — but note the *directory* it
+lives in inside this repo is `workflow/gds2palace/`, not the repo root; when reading example
+scripts you'll often see `sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'gds2palace')))`
+before `from gds2palace import *` — that's for running a script directly against the in-repo source
+without installing the package (see `pyproject.toml`'s `[tool.setuptools.packages.find]`, which
+publishes `workflow/gds2palace/` as the top-level `gds2palace` package).
+
+---
+
+## 3. Stackup XML format, `stackupEditor`, and agent-driven stackup generation
+
+Every model script needs an XML "stackup" file — layer stack, materials, via rules — read via
+`stackup_reader.read_substrate()` (§4 step 4). This section covers the file format itself, the GUI
+tool for editing it, and — most relevant to an agent with no GUI — **how to generate or edit one
+programmatically**, using the exact functions the GUI itself is built on.
+
+### 3.1 — File format
+
+Format spec: `doc/XML_stackup_format/XML_stackup_format.md` (this repo); related:
+`doc/XML_stackup_format/derived_layers.md`, `doc/XML_stackup_format/evolution_of_stackup_file_format.md`.
+Top-level structure:
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Stackup schemaVersion="2.0">
+  <Variables>...</Variables>        <!-- optional, must be the FIRST child -->
+  <Materials>...</Materials>
+  <ELayers LengthUnit="um">
+    <Dielectrics>...</Dielectrics>
+    <Layers>...</Layers>
+    <DerivedLayers>...</DerivedLayers>  <!-- optional -->
+  </ELayers>
+  <Tables>...</Tables>               <!-- optional, thermal conductivity tables -->
+</Stackup>
+```
+
+Smallest real example in the repo, `workflow/pcb_ro4003.xml` (full file, verified):
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+  <Stackup schemaVersion="2.0">
+    <Materials>
+      <Material Name="Copper" Type="Conductor" Permittivity="1" DielectricLossTangent="0" Conductivity="3.3e7" Color="00ff00"/>
+      <Material Name="RO4003" Type="Dielectric" Permittivity="3.38" DielectricLossTangent="0.0022" Conductivity="0" Color="01e0ff"/>
+      <Material Name="AIR" Type="Dielectric" Permittivity="1.0" DielectricLossTangent="0.0" Conductivity="0" Color="d0d0d0"/>
+    </Materials>
+    <ELayers LengthUnit="um">
+      <Dielectrics>
+        <Dielectric Name="RO4003" Material="RO4003" Thickness="510" />
+      </Dielectrics>
+      <Layers>
+        <Substrate Offset="0"/>
+        <Layer Name="Bottom" Type="Conductor" Zmin="-17" Zmax="0" Material="Copper" Layer="1" />
+        <Layer Name="Top" Type="Conductor" Zmin="510" Zmax="527" Material="Copper" Layer="10" />
+      </Layers>
+    </ELayers>
+  </Stackup>
+```
+
+**`<Materials>`** — one `<Material>` per material: `Name`, `Type` (`Conductor`/`Dielectric`/
+`Semiconductor`/`Resistor`), `Permittivity`, `DielectricLossTangent`, `Conductivity`, `Rs`, plus
+thermal-only `Density`/`ThermalConductivity`/`ThermalConductivityTable`, and a `Color` (hex, used
+by the stackup preview).
+
+**`<Dielectrics>`** — the vertical dielectric stack, independent of GDSII, listed top-to-bottom.
+Position is resolved by priority: (1) explicit `Zmin`+`Zmax`, (2) Reference-relative
+(`Reference="<other Dielectric Name>"` + optional `ReferenceEdge`, default `Top`; own `Zmin`
+defaults `0`, `Zmax` defaults `Zmin+Thickness`), (3) legacy implicit stacking by `Thickness` alone.
+
+**`<Layers>`** — drawn, GDSII-sourced layers. `Type` ∈ `conductor`/`via`/`dielectric`/`sheet` —
+maps 1:1 to `util_stackup_reader.py`'s `metal_layer.is_metal`/`is_via`/`is_dielectric`/`is_sheet`
+flags (`util_stackup_reader.py:909-974`, see also §4's canonical-pattern walkthrough); `Zmin==Zmax`
+forces `sheet` regardless of the stated `Type`. `<Substrate Offset="...">` shifts every Layer's z
+by a fixed amount — mutually exclusive with any `Reference`-based Layer in the same file.
+
+**Reference-relative positioning** (`schemaVersion="3.0"+`) replaces hand-recomputed absolute
+z-values and the single global `Substrate Offset` fudge factor with a `Reference`/`ReferenceEdge`
+chain, resolved in dependency order regardless of file order — so a whole stack no longer needs
+re-deriving by hand whenever one Dielectric's thickness changes.
+
+**`<DerivedLayers>`** (`schemaVersion="3.0"+`) — computes a new GDSII layer number from existing
+ones via boolean ops `AND`/`OR`/`XOR`/`NOT` (≥2 operands, folded pairwise) or `SIZE` (1 operand,
+resize by `Oversize`). Operands may chain off other derived layers (topologically sorted). Full
+detail: `doc/XML_stackup_format/derived_layers.md`.
+
+**`<Variables>`** (`schemaVersion="3.1"+`, current `SUPPORTED_SCHEMA_VERSION`,
+`util_stackup_reader.py:66`) — must be the first child of `<Stackup>`. Any attribute value anywhere
+in the file starting with `=` is an expression (`+ - * / **`, parens, references to other Variables
+by name), resolved in dependency order with circular-reference detection:
+```xml
+<Variables>
+  <Variable Name="cu_conductivity" Value="21640000.0" />
+  <Variable Name="via_top" Value="=metal_thickness + via_thickness" />
+</Variables>
+```
+`stackup_reader.read_substrate(XML_filename, variable_overrides={...})` lets a model script
+override a named Variable at run time without editing the XML — the mechanism setupEM's "Override
+stackup Variables" grid feeds into.
+
+### 3.2 — `stackupEditor`: what it is, and what it's built on
+
+`stackupEditor` is a PySide6 GUI (`setupEM/src/setupEM/stackupEditor.py`, `StackupEditorWindow`,
+console script `stackupEditor = "setupEM.stackupEditor:main"`, in the sibling `setupEM` repo) for
+editing stackup XML files without hand-editing — Variables, Materials, Dielectric stack, Layers,
+Derived Layers, and thermal Tables, each as an editable grid, plus a live cross-section preview.
+
+**The important architectural fact for an agent: the GUI holds no separate, richer domain model of
+its own.** Its single source of truth is a plain `xml.etree.ElementTree` (`self.tree`),
+loaded/created via `stackup_writer.load_stackup_tree(filename)` / `stackup_writer.new_stackup_tree()`.
+Every tab is a generic `ElementTableEditor` widget parameterized with plain `stackup_writer`
+functions as callbacks, e.g.:
+```python
+add_fn=lambda root, **attrs: stackup_writer.add_material(root, **attrs),
+remove_fn=stackup_writer.remove_material,
+type_choices=list(stackup_writer.VALID_MATERIAL_TYPES),
+```
+So editing a row in the GUI just calls the same `stackup_writer.add_material()`/`remove_material()`/
+etc. an agent would call directly. There is no intermediate GUI-only object an agent needs to
+reconstruct.
+
+### 3.3 — `stackup_writer.py`: the actual, GUI-independent XML editing API
+
+`setupEM/src/setupEM/stackup_writer.py` (1347 lines) is a **standalone module with zero Qt/GUI
+dependency** — its only imports are `ast`, `xml.etree.ElementTree`, and
+`from gds2palace import stackup_reader` (itself pure stdlib). Its own docstring states the intent
+directly: it's deliberately kept separate from `util_stackup_reader.py` because *"the reader turns
+XML into the read-only object model ... used by the rest of gds2palace, while this module is for
+tools that need to load a file, edit it ..., and write it back out ... while leaving any parts of
+the file they don't understand (e.g. XML comments) completely untouched."*
+
+**This means: an AI agent can generate or edit a stackup XML file by importing `stackup_writer`
+directly and calling it — no GUI, no Qt event loop, no `QApplication` — exactly the functions
+`stackupEditor` itself calls.**
+
+Full public API (function names/signatures verified directly against source):
+```python
+load_stackup_tree(filename)                                   # -> ElementTree, comment-preserving parse
+new_stackup_tree(length_unit="um", schema_version="2.0")       # -> ElementTree, minimal empty <Stackup>
+save_stackup_tree(tree, filename)                               # writes to disk, self-corrects schemaVersion
+
+get_materials_element(root) / get_dielectrics_element(root) / get_layers_element(root)
+get_substrate_offset_element(root) / get_derived_layers_element(root, create=False)
+get_variables_element(root, create=False) / get_tables_element(root, create=False)
+
+add_material(root, **attrs)  / remove_material(root, element)
+add_dielectric(root, index=None, **attrs)  / remove_dielectric(root, element)
+move_dielectric(root, element, direction)      # direction: -1 up / +1 down
+add_layer(root, **attrs)  / remove_layer(root, element)
+set_substrate_offset(root, value)              # value None/0 removes the <Substrate> element
+add_derived_layer(root, **attrs)  / remove_derived_layer(root, element)
+get_operand_layers(element) / set_operands(element, layer_numbers)
+add_variable(root, **attrs)  / remove_variable(root, element)
+add_table(root, **attrs)  / remove_table(root, element)
+add_point(table_element, **attrs)  / remove_point(table_element, element)
+
+validate_stackup(root)          # -> list[str] of problems, [] if OK
+required_schema_version(root)   # -> "2.0"/"3.0"/"3.1", the minimum actually needed by file content
+stamp_header_comments(root, app_name, description="")
+get_file_description(root)      # -> str
+```
+`add_*`/`remove_*` take/return plain `Element` objects; keyword arguments become XML attributes
+directly (`None`/`""` values are skipped). `VALID_MATERIAL_TYPES`, `VALID_LAYER_TYPES`,
+`VALID_DERIVED_OPERATIONS` module-level tuples give the exact allowed values for each `Type`/
+`Operation` field.
+
+**Comment preservation is real, not just a GUI-editor claim**: `load_stackup_tree()` uses a custom
+comment-preserving parser (`ET.TreeBuilder(insert_comments=True)`), so hand-written
+`<!-- comments -->` in a file survive an agent's load→edit→save round-trip untouched — including
+any `<Tables>` content, which the writer's own logic never touches at all.
+
+**Worked example** — generating the `pcb_ro4003.xml` file above from scratch, using nothing but
+`stackup_writer`:
+```python
+from setupEM import stackup_writer
+
+tree = stackup_writer.new_stackup_tree(length_unit="um", schema_version="2.0")
+root = tree.getroot()
+
+stackup_writer.add_material(root, Name="Copper", Type="Conductor",
+                             Permittivity="1", DielectricLossTangent="0",
+                             Conductivity="3.3e7", Color="00ff00")
+stackup_writer.add_material(root, Name="RO4003", Type="Dielectric",
+                             Permittivity="3.38", DielectricLossTangent="0.0022",
+                             Conductivity="0", Color="01e0ff")
+
+stackup_writer.add_dielectric(root, Name="RO4003", Material="RO4003", Thickness="510")
+
+stackup_writer.set_substrate_offset(root, 0)
+stackup_writer.add_layer(root, Name="Bottom", Type="conductor",
+                          Zmin="-17", Zmax="0", Material="Copper", Layer="1")
+stackup_writer.add_layer(root, Name="Top", Type="conductor",
+                          Zmin="510", Zmax="527", Material="Copper", Layer="10")
+
+errors = stackup_writer.validate_stackup(root)
+if errors:
+    raise SystemExit("\n".join(errors))
+
+stackup_writer.stamp_header_comments(root, app_name="agent-script",
+                                      description="Generated programmatically")
+stackup_writer.save_stackup_tree(tree, "pcb_ro4003_generated.xml")
+```
+(`stackup_writer` is a plain submodule of the installed `setupEM` package — not re-exported from
+`setupEM`'s own top-level `__init__.py` (which only exports `main`), so
+`import setupEM.stackup_writer as stackup_writer` / `from setupEM import stackup_writer` both work,
+but `from setupEM import *` will not surface it.)
+
+**Cross-repo note**: `stackup_writer.py` lives in the `setupEM` repo, not this one —
+`gds2palace_ihp_sg13g2` has no writer of its own (`util_stackup_reader.py` only reads). Using it
+requires `setupEM` installed alongside `gds2palace` (`setupEM`'s own `pyproject.toml` already
+depends on `gds2palace>=0.4.0`, never the reverse — confirmed no `setupEM` reference anywhere in
+this repo's `pyproject.toml`).
+
+### 3.4 — Does an agent-generated file actually round-trip through gds2palace's reader?
+
+Reasonably reliably, and not just by construction — **`stackup_writer.save_stackup_tree()` actively
+exercises gds2palace's own `stackup_reader.parse_substrate()`** as part of every save, to resolve
+sort order for Layers (by resolved `Zmin`) and Table points (by resolved `Temperature`), and
+`required_schema_version()`/`validate_stackup()` run their own independent checks beforehand. So a
+file that passes `validate_stackup(root)` cleanly and saves without error has already been parsed
+once by the real reader logic before it ever reaches disk. The one caveat: the save-time sort steps
+silently skip their cosmetic reordering (not fail the whole save) if `parse_substrate()` raises —
+so a clean `validate_stackup()` result plus a successful save is strong, but not
+absolutely 100%-exhaustive, evidence the file will read back correctly. **The definitive check
+remains calling `gds2palace.stackup_reader.read_substrate()` on the generated file directly** and
+confirming no exception.
+
+---
+
+## 4. The canonical model-script pattern
+
+Traced end-to-end from `workflow/palace_rfcmim.py` (a hand-written RF MIM capacitor model — chosen
+as representative because it's not one of the more elaborate synthesis/sweep scripts) and
+cross-checked against `workflow/line_simple_viaport.py`. Every model script in this repo — hand
+written, setupEM-generated, or the inductor synthesis scripts (§12) — follows this same sequence.
+
+```python
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'gds2palace')))
+from gds2palace import *
+
+# --- 1. path/output-directory bootstrap ---
+script_path    = utilities.get_script_path(__file__)
+model_basename = utilities.get_basename(__file__)
+sim_path       = utilities.create_sim_path(script_path, model_basename)
+
+# --- 2. settings dict (plain dict, see §6 for the full key reference) ---
+settings = {}
+settings['unit']              = 1e-6
+settings['margin']            = 50
+settings['fstart']            = 1e9
+settings['fstop']             = 20e9
+settings['fstep']             = 1e9
+settings['refined_cellsize']  = 2
+
+XML_filename = "SG13G2_nosub.xml"
+gds_filename = "my_layout.gds"
+
+# --- 3. ports ---
+simulation_ports = simulation_setup.all_simulation_ports()
+simulation_ports.add_port(simulation_setup.simulation_port(
+    portnumber=1, voltage=1, port_Z0=50, source_layernum=201,
+    from_layername='Metal1', to_layername='TopMetal1', direction='z'))
+simulation_ports.add_port(simulation_setup.simulation_port(
+    portnumber=2, voltage=1, port_Z0=50, source_layernum=202,
+    from_layername='Metal1', to_layername='Metal5', direction='z'))
+
+# --- 4. read the stackup ---
+materials_list, dielectrics_list, metals_list = stackup_reader.read_substrate(XML_filename)
+
+# --- 5. build the layer list to extract, and read the GDSII ---
+layernumbers = metals_list.getlayernumbers()
+layernumbers.extend(simulation_ports.portlayers)
+allpolygons = gds_reader.read_gds(gds_filename, layernumbers, purposelist=[0],
+    metals_list=metals_list, preprocess=True, merge_polygon_size=0)
+
+# --- 6. stuff everything the engine needs into settings ---
+settings['simulation_ports'] = simulation_ports
+settings['materials_list']   = materials_list
+settings['dielectrics_list'] = dielectrics_list
+settings['metals_list']      = metals_list
+settings['layernumbers']     = layernumbers
+settings['allpolygons']      = allpolygons
+settings['sim_path']         = sim_path
+settings['model_basename']   = model_basename
+
+# --- 7. build the model (writes config.json + mesh + port_information.json) ---
+excite_ports = simulation_ports.all_active_excitations()
+config_name, data_dir = simulation_setup.create_palace(excite_ports, settings)
+
+# --- 8. write the convenience run script into sim_path ---
+utilities.create_run_script(sim_path)
+```
+
+### What each call actually does
+
+- **`utilities.create_sim_path(script_path, model_basename, dirname='palace_model')`**
+  (`util_utilities.py:54-83`) builds `<script_dir>/palace_model/<model_basename>_data/` and
+  creates it (`os.makedirs`). On Windows, if the resulting path would exceed 200 characters, or if
+  directory creation fails for any other reason, it silently falls back to a directory under the
+  system temp dir instead (`util_utilities.py:67-81`) — worth knowing if a generated model's
+  output ends up somewhere unexpected on a Windows box with a deeply-nested repo path.
+
+- **`simulation_setup.simulation_port(...)`** (`util_simulation_setup.py:33-78`) validates, at
+  construction time, that you've specified either a **via port** (`direction` contains `z`/`Z`,
+  plus `from_layername` + `to_layername`) or an **in-plane port** (`direction` contains `x`/`y`,
+  plus `target_layername`) — anything else prints an error and calls `exit(1)` immediately
+  (`:60-68`). There is no gentler failure mode here; a malformed port definition kills the whole
+  script at construction time, before any geometry or meshing work happens.
+
+- **`all_simulation_ports.all_active_excitations()`** (`:160-172`) returns only the ports whose
+  `abs(voltage) > 1e-6` — a `voltage=0` port is *defined* (its geometry still gets built and it
+  still appears as a matrix row/column) but never *excited*. This is the mechanism used throughout
+  the repo to cheaply simulate "just this one path" of a larger multi-port structure — see the
+  ATTENTION callout in §8.
+
+- **`stackup_reader.read_substrate(XML_filename, variable_overrides=None)`**
+  (`util_stackup_reader.py:1456-1482`) parses the XML with a comment-preserving `ElementTree`
+  parser, validates `schemaVersion`, and returns exactly the 3-tuple
+  `(materials_list, dielectrics_list, metals_list)`. `metals_list` also carries
+  `.derived_layers` for the boolean-operation "derived layer" feature (§3.1). `variable_overrides`
+  is a dict of `{variable_name: value}` used to override a `<Variables>`-declared value from Python
+  without editing the XML file — this is exactly the mechanism setupEM's "Override stackup
+  Variables" grid feeds into.
+
+- **`gds_reader.read_gds(filename, layerlist, purposelist, metals_list, preprocess=False,
+  merge_polygon_size=0, mirror=False, offset_x=0, offset_y=0, gds_boundary_layers=[],
+  layernumber_offset=0, cellname="", derived_layers=None)`** (`util_gds_reader.py:502-524`) opens
+  the GDS via `gdspy.GdsLibrary`, flattens the top-level cell, and for each requested layer number
+  extracts layer/datatype polygons matching `purposelist`. Via-array polygons get merged when
+  `metal.is_via` and `merge_polygon_size > 0` (`merge_via_array`, `:596-597`). **Known
+  documentation drift worth flagging**: the `preprocess` argument is currently a no-op that just
+  prints a message (docstring/comment at `:511`/`:534-536` says polygon-cutout handling is
+  "obsolete, cutouts are handled safely downstream after flattening") — but
+  `doc/userguide_md_format/gds2palace_workflow_userguide.md:321` still describes it as an active
+  preprocessing step. If you're an agent reasoning from the user guide alone, don't assume
+  `preprocess_gds=True/False` changes behavior; check the current source before relying on it.
+
+- **`simulation_setup.create_palace(excite_ports, settings)`** (`:1054-1066`) is a thin wrapper —
+  it just calls `create_model(excite_ports, settings)`. Palace is the *default* mode.
+  `create_elmer(excite_ports, settings)` (`:1015-1029`) sets `settings['elmer']=True` then calls
+  the same `create_model()`. `create_elmer_thermal(settings)` (`:1032-1051`, no `excite_ports` —
+  thermal has no EM ports) sets `settings['elmer']=True, settings['elmer_thermal']=True` and dummy
+  `fstart=fstop=1e9` (mesh-only frequencies). **All three funnel into one 1620-line function,
+  `create_model()`** (`:1071-2693`) — this is the actual engine. In order, it:
+  1. Pulls every setting out of the `settings` dict with defaults via a local
+     `get_optional_setting(settings, key, default)` closure (`:1082-1084`) — unrecognized/missing
+     optional keys fall back to sane defaults rather than raising.
+  2. `gmsh.initialize()`, creates a fresh gmsh model (`:1276-1288`).
+  3. `add_metal_volumes(...)` (`:1339`) — turns each drawn polygon into a gmsh 3D volume or 2D
+     surface depending on the corresponding XML `<Layer>` type (via / dielectric-brick / sheet /
+     planar metal).
+  4. `add_dielectrics(...)` (`:1352`) — builds the stackup dielectric boxes and, unless doing
+     thermal, an outer airbox sized by `margin`/`air_around`.
+  5. Boolean-cuts metal out of dielectric (`gmsh.model.occ.cut`, `:1388`), then
+     `gmsh.model.occ.fragment(...)` (`:1404`) to conformally stitch everything together.
+  6. `add_ports(...)` — builds port 2D-sheet surfaces and writes `port_information.json` (port
+     number, `Z0`, direction, geometry, in microns) into `sim_path` (`:1770-1781`) — this file is
+     gds2palace's own metadata, consumed later by the Touchstone-conversion script (§9), never by
+     Palace itself.
+  7. Assigns gmsh physical groups for every conductor/dielectric/boundary entity.
+  8. **Palace path** (`if not elmer:`, `:2171-2174`): writes `config.json` — a nested dict with
+     `Problem` (`Type`, `Verbose`, `Output` = `"output/<model_basename>"`), `Model` (mesh filename,
+     `L0`, AMR `Refinement` block), `Solver` (linear-solver params, `Order`, `Device: "CPU"`,
+     `Driven.Samples` frequency list, `AdaptiveTol`), `Domains.Materials` (keyed by numeric gmsh
+     physical-group `Attributes`), and `Boundaries` (`Conductivity`, `LumpedPort`, optionally
+     `Impedance`/`Absorbing`/`PEC`/`PMC`) — built at `:1800-2167`.
+  9. **Elmer path** (`if elmer:`, `:2181-2397`): builds equivalent `Elmer_*` structures and calls
+     `util_elmer.write_elmer_frequencies/write_elmer_physics_file/write_elmer_thermal_file/
+     write_case_and_solver_files`, plus writes `ELMERSOLVER_STARTINFO`.
+  10. Mesh-size fields from `refined_cellsize`/`refined_cellsize_override`/`meshsize_max`/
+      `cells_per_wavelength` (~`:2400-2640`), optional gmsh GUI preview (`gmsh.fltk.run()`, unless
+      `no_gui`/`no_preview`), then `gmsh.model.mesh.generate(3)` and `gmsh.write(msh_name)` —
+      **forcing `Mesh.MshFileVersion = 2.2`**, because, per the comment at `:2655`, *"Palace
+      requires mesh version 2.2!"*
+  11. For Elmer: `util_elmer.convert_mesh_to_elmer(msh_name, ELMER_MPI_THREADS)` (`:2690-2691`)
+      converts the `.msh` to Elmer's native mesh format via the external `ElmerGrid` tool.
+  12. Returns `(config_name, data_dir)` — `data_dir` is literally the string
+      `'output/' + model_basename` (`:1229`), a relative path baked into `config.json`'s
+      `Problem.Output`. **Palace itself creates that `output/` directory when it runs** — gds2palace
+      never creates it.
+
+- **`utilities.create_run_script(sim_path)`** (`util_utilities.py:86-102`) writes a convenience
+  wrapper — see §5.4 for exact content and why it exists.
+
+### Concrete files a Palace run produces (verified against a real generated directory)
+
+`<script_dir>/palace_model/<model_basename>_data/`:
+```
+config.json                    # Palace's solver-control file (written by gds2palace)
+<model_basename>.msh           # gmsh mesh, forced to format version 2.2 (written by gds2palace)
+port_information.json          # gds2palace's own port metadata (written by gds2palace)
+run_sim                        # convenience wrapper (written by gds2palace, see §5.4)
+mesh_convergence_summary.txt   # only if adaptive_mesh_iterations > 0
+output/                        # created BY PALACE ITSELF when it runs — empty/absent until then
+```
+For Elmer:
+```
+case.sif  ELMERSOLVER_STARTINFO  first-order.sif  frequencies.dat  physics.sif
+quadratic-direct.sif  quadratic-iterative.sif  run_elmer  port_information.json
+<model_basename>.msh   mesh/    # ElmerGrid-converted mesh partition directory
+```
+
+---
+
+## 5. "Palace itself is not included" — what that means concretely
+
+### 5.1 — Confirmed: not a Python dependency
+
+`pyproject.toml`:
+```toml
+[project]
+name = "gds2palace"
+...
+dependencies = [
+    "gdspy>1.6.0",
+    "gmsh",
+]
+```
+Only `gdspy` and `gmsh` are pip dependencies. **No `palace`, no MPI bindings, nothing
+solver-related.** `pip install gds2palace` gives you the model-file *generator*, nothing that can
+actually run an FEM solve.
+
+### 5.2 — What this package does vs. what it explicitly does not do
+
+- `README.md:26`: *"It creates model files for the AWS Palace FEM solver, which must be installed
+  separately, as described in chapter 'Installing Palace'."*
+- `README.md:63`: *"The gds2palace workflow does not change, it only creates the input files for
+  Palace and does not care how you installed Palace, or on what platform you run the actual Palace
+  simulation from these model files."*
+
+So concretely: gds2palace's job stops at producing `<model>.msh` + `config.json` (+
+`port_information.json`) inside `palace_model/<name>_data/`. Actually **running** the FEM solve —
+the compute-heavy, MPI-parallel, compiled C++/MFEM binary that reads that `.msh` + `config.json`
+and produces raw S-parameters — is entirely external to this repo and this package.
+
+### 5.3 — What a user or agent must install/provide separately
+
+Two documented installation paths for the Palace binary, **both Linux-only**
+(`README.md:25`: *"This workflow is designed for Linux systems"*):
+
+1. **Apptainer/Singularity container** (the author's own recommended path):
+   `apptainer pull palace_016.sif oras://ghcr.io/volkermuehlhaus/palace_016:latest`
+   (`README.md:52`). Documented in `doc/Installing_Palace_using_Apptainer.pdf` (present in the
+   repo; PDF, not inlined as markdown anywhere).
+2. **Build from source via the Spack package manager** — `doc/Installing_Palace_using_Spack.pdf`.
+
+Either way, the repo's own reference launcher, **`scripts/run_palace`** (full file, 2 lines):
+```bash
+#!/bin/bash
+apptainer exec ~/palace.sif palace -np 8 $1
+```
+This runs the `palace` binary *inside* a container image at `~/palace.sif`, with Palace's own
+`-np 8` flag telling it to partition the simulation domain across 8 MPI processes, and `$1` (the
+first CLI argument, expected to be `config.json`) passed straight through.
+
+**`scripts/README.md` is explicit that this is just the author's own dev setup, not a
+requirement**: *"If you prefer to install and run Palace in a different way, no problem! The
+gds2palace workflow creates the input files for Palace, and it is entirely your choice how you run
+the simulator with these model files, local or on a sophisticated HPC cluster."*
+
+There's also **`scripts/run_palace_remote`**, meant to be renamed to `run_palace` in place of the
+local version: it `scp`s the entire model output directory to a remote Linux machine, `ssh`es in
+and runs that machine's own `run_sim` (see §5.4 below) there, then `scp`s the resulting `output/`
+directory back — i.e. Palace execution is fully decoupled from wherever the Python model-generation
+step ran (you can generate model files on Windows/macOS and simulate on a remote Linux box).
+
+### 5.4 — The generated per-model `run_sim` wrapper (distinct from `scripts/run_palace`)
+
+`utilities.create_run_script(sim_path)` (called at the end of every model script, §4 step 8) writes
+this exact content into `<sim_path>/run_sim` (`util_utilities.py:91-93`):
+```bash
+#!/bin/bash
+run_palace config.json
+combine_snp
+```
+(written with forced Unix line endings even on Windows, and `chmod 0o755`'d only when actually
+running on Linux — `util_utilities.py:96-102`).
+
+**The relationship between the two:**
+- `run_sim` is generated **fresh into every model's own output directory** by gds2palace. It
+  contains no simulator-specific configuration — it's purely "solve this model, then convert its
+  results," and it calls `run_palace`/`combine_snp` as bare commands, relying on `$PATH`.
+- `run_palace` (and `combine_snp`) are **general-purpose, hand-configured-once-per-machine**
+  scripts that must exist somewhere on `PATH` (`scripts/README.md`: *"Include the script folder to
+  your PATH"*). They decide *how* Palace actually launches on this particular machine (which
+  container image, how many cores, or — via the renamed `run_palace_remote` — dispatch to a
+  different machine entirely).
+
+**An agent generating a new model should call `utilities.create_run_script(sim_path)` exactly as
+existing scripts do, and should assume a working `run_palace` + `combine_snp` already exist on
+`PATH` in the target execution environment — it should not try to reimplement Palace invocation
+logic itself.**
+
+Some model scripts additionally offer an in-Python auto-run toggle right after `create_palace()`:
+```python
+start_simulation = False
+run_command = ['./run_sim']
+...
+if start_simulation:
+    os.chdir(sim_path)
+    subprocess.run(run_command, shell=True)
+```
+— i.e. the model script itself can `cd` into the freshly-created output directory and shell out to
+`./run_sim` immediately after generating it.
+
+**Elmer equivalent**: `utilities.create_elmer_run_script(sim_path, settings)` writes `run_elmer`
+into `sim_path`, either:
+```bash
+#!/bin/bash
+ElmerSolver
+combine_snp
+```
+(single-threaded, when `settings['ELMER_MPI_THREADS']` is 1 or unset) or:
+```bash
+#!/bin/bash
+mpirun -np 8 ElmerSolver case.sif
+combine_snp
+```
+(multi-threaded — the exact `-np N` value comes from `util_elmer.get_ELMER_MPI_THREADS(settings)`).
+
+---
+
+## 6. `settings` dict — the full key reference
+
+`settings` is a **plain Python dict**, not a class, passed straight into
+`simulation_setup.create_palace(excite_ports, settings)` / `create_elmer(...)`. This table is
+reproduced from `doc/userguide_md_format/gds2palace_workflow_userguide.md:333-362` (verified
+against the source, e.g. `get_optional_setting` defaults in `util_simulation_setup.py:1082-1224`).
+
+**Always required:**
+
+| Key | Meaning |
+|---|---|
+| `unit` | Unit of values in mesh, typically `1e-6` (micron) |
+| `margin` | Oversize of dielectrics from the drawing's bounding box, in the xy plane |
+| `fstart`, `fstop`, `fstep` | Frequency sweep, in Hz. Not every step is necessarily EM-simulated, due to the adaptive frequency sweep |
+| `refined_cellsize` | Target mesh size at polygon edges, in `unit` |
+
+**Optional — discrete frequencies in addition to / instead of the sweep:**
+
+| Key | Meaning |
+|---|---|
+| `fpoint` | List of discrete frequencies, e.g. `[10e9, 15e9]` |
+| `fdump` | Like `fpoint`, but Palace also writes a field dump for Paraview at these frequencies — see §10 |
+
+**Optional — everything else:**
+
+| Key | Default | Meaning |
+|---|---|---|
+| `cells_per_wavelength` | 10 | Calculated at the highest frequency; must be ≥10 |
+| `meshsize_max` | 70 | Maximum mesh size limit, on top of `cells_per_wavelength` |
+| `refined_cellsize_override` | `[]` | Per-layer override, e.g. `[['Metal3', 10], ['Metal2', 2]]`. Only conductor/sheet layers produce the boundary curves this applies to — a via or dielectric layer name (or any typo/nonexistent name) is a plain dict-key miss inside `create_model()`, silently ignored with no error (`util_simulation_setup.py`'s `refined_cellsize_override_dict` lookup, fed only by `boundary_line_tags_dict`, which vias/dielectrics never populate). setupEM's own "Advanced..." mesh-override dialog restricts its layer picker to valid conductor/sheet layers for exactly this reason. |
+| `boundary` | `['ABC']*6` | 6 values for xmin/xmax/ymin/ymax/zmin/zmax: `ABC`/`PML`, `PEC`, or `PMC` |
+| `air_around` | same as `margin` | Single value, or a list of 6 `[xmin,xmax,ymin,ymax,zmin,zmax]` values. `0` is allowed on any side (e.g. a backside ground plane flush with the simulation boundary, no wasted air layer) |
+| `order` | 2 | FEM basis-function order (2 = accurate; 1 = quick/dirty) — see §7 for what this actually does to accuracy |
+| `substrate_refinement` | `False` | Extra mesh refinement into the substrate |
+| `adaptive_sweep` | `True` | Enable Palace's adaptive frequency sweep |
+| `adaptive_mesh_iterations` | 0 | AMR iterations — often unnecessary with a fine initial mesh |
+| `save_adaptive_mesh` | `False` | Save the AMR-iteration mesh for reuse |
+| `save_gmsh_unrolled` | `False` | Also save the unmeshed gmsh geometry, for inspection |
+| `z_thickness_factor` | 1 | Factor on metal-thickness for conductor side walls (relevant when skin depth exceeds metal thickness) |
+| `no_gui` | `False` | Don't show the gmsh UI — for unattended/scripted runs |
+| `no_preview` | `False` | Skip the unmeshed-geometry preview, go straight to showing the meshed model |
+
+**Not user-facing settings, but required in the dict before calling `create_palace`/`create_elmer`**
+(built during steps 4-6 of §4, not typed by hand): `simulation_ports`, `materials_list`,
+`dielectrics_list`, `metals_list`, `layernumbers`, `allpolygons`, `sim_path`, `model_basename`.
+
+---
+
+## 7. FEM order and what it does to accuracy
+
+`settings['order']` selects the polynomial order of the finite-element basis functions Palace uses
+within each mesh cell (tetrahedron): 1 (linear), 2 (quadratic, the default), or 3 (cubic). Enforced
+in code (`util_simulation_setup.py:1156-1159`): any value outside `1-3` prints a warning and falls
+back to `order=2`. It maps directly to `config.json`'s `Solver.Order` field (`:1897`).
+
+**What raising the order actually buys you**: a higher-order basis function can represent field
+variation *within a single mesh cell* more accurately (more degrees of freedom per cell), so a
+coarser mesh (larger `refined_cellsize`) can reach the same accuracy as a much finer mesh at a
+lower order. Conversely, order=1 needs a denser mesh to resolve the same field distribution
+accurately — this is the classic FEM p-refinement (raise polynomial order) vs. h-refinement (refine
+the mesh) trade-off.
+
+The user guide documents a real head-to-head comparison for exactly this trade-off
+(`doc/userguide_md_format/gds2palace_workflow_userguide.md:430-485`, an 880 µm long / 15 µm-wide
+TopMetal2-over-Metal1 microstrip line testcase), simulated four different ways:
+
+| `refined_cellsize` | `order` | Simulation time | Degrees of freedom (DOF) |
+|---|---|---|---|
+| 2 µm | 1 | 64 s | 321,999 |
+| 5 µm | 2 | 282 s | 699,658 |
+| **2 µm** | **2 (default)** | **733 s** | **1,640,126** |
+| 5 µm | 3 | 1967 s | 1,982,661 |
+
+Findings from that comparison, quoted/paraphrased from the user guide:
+- **order=1 is a clear outlier** — visibly different S11/S21 magnitude and phase from every
+  higher-order configuration, regardless of mesh density. Treat order=1 as "quick/dirty" only,
+  never for a final result.
+- **`refined_cellsize=5, order=3` reproduces the `refined_cellsize=2, order=2` baseline almost
+  exactly** (S11 and S21 magnitude/phase visually identical) — confirming a higher basis-function
+  order really can substitute for a finer mesh.
+- But in this case that substitution was **not a good trade**: it took *more* DOF and nearly 3×
+  the simulation time (1967 s vs. 733 s) to match the accuracy the default
+  (`refined_cellsize=2, order=2`) already gave more cheaply. The guide's own conclusion:
+  *"refined_cellsize=2, order=2 is the best choice for accurate data... at less simulation time."*
+
+**Practical guidance for an agent choosing these settings**: don't reach for `order=3` as a first
+move to improve accuracy — try tightening `refined_cellsize` at the default `order=2` first, and
+only escalate to `order=3` if a documented convergence check (e.g. via `adaptive_mesh_iterations`,
+or a manual before/after comparison like the one above) shows it's actually needed. `order=1`
+should be reserved for fast exploratory sweeps where some visible error is acceptable — this is
+exactly how the inductor-synthesis examples in §12 use it (`order=1` for a broad coarse sweep
+across dozens of candidates, `order=2` only for the finalists).
+
+**Elmer note**: Elmer's EM solver only supports `order` 1 or 2 — "other values fall back to the
+order-1 solver recipe" (`doc/userguide_md_format/gds2palace_workflow_userguide.md:827`). `order=3`
+is Palace-only.
+
+---
+
+## 8. Ports
+
+Ports are geometry-driven: **drawn as polygons on special GDSII layers** (conventionally 201 and
+up) that are not part of the real IHP layer table, then mapped by `simulation_port(...)` to real
+technology layers via `from_layername`/`to_layername` (vertical/via port) or `target_layername`
+(in-plane port), plus a `direction` (`x`/`y`/`z`, case-insensitive per `util_simulation_setup.py`'s
+`Z in self.direction.upper()`-style checks).
+
+**Two structural quirks worth knowing:**
+
+1. **`voltage` doesn't mean voltage to Palace** — Palace itself doesn't support the `voltage`
+   parameter; it only supports polarity reversal by flipping port direction. This workflow instead
+   *repurposes* `voltage` as an excitation on/off switch: **`voltage=0` means "define this port's
+   geometry, but don't excite it."** `all_simulation_ports.all_active_excitations()` filters out
+   any port with `abs(voltage) <= 1e-6` before it's passed to `create_palace(...)`.
+2. **Palace runs one excitation at a time, sequentially.** To get a full S-matrix you must define
+   *every* port with a nonzero voltage — Palace then simulates each excitation, one after another,
+   automatically. **If any port is left at `voltage=0`, its row in the S-parameter output is
+   entirely absent (later padded with zeros by the Touchstone converter, §9)** — this is a
+   deliberate, useful trick for cheaply simulating just one signal path of a larger multi-port
+   structure, not a bug.
+
+Port shape requirement: ports are **2D-sheet lumped ports**. For a vertical (via) port, draw a
+zero-width box in GDSII (a line, effectively) — a finite-area box still works, but the port sheet
+is placed along its centerline. Composite ports (multiple EM ports grouped into one logical port)
+are **not supported**.
+
+---
+
+## 9. From raw Palace output to Touchstone `.snp`
+
+### 9.1 — `port-S.csv` is Palace's own native output, not something gds2palace writes
+
+gds2palace's only involvement in Palace's output is setting `config.json`'s
+`Problem.Output = "output/<model_basename>"` (`util_simulation_setup.py:1802-1807`) — a relative
+path telling Palace where to write its own results. **Palace itself** creates that `output/`
+directory and writes `port-S.csv` (and other files) into it when it actually runs — the CSV's
+column-header convention (`|S[i][j]|`/`arg(S[i][j])`, `(dB)`/`(deg.)` suffixes) is Palace's native
+format, not anything gds2palace defines.
+
+gds2palace does separately write its own metadata file, `port_information.json`, directly into
+`sim_path` (one level up from Palace's `output/<model>/` folder) — port number, `Z0`, direction,
+geometry (length/width/position), and `unit`. This is *not* consumed by Palace; it's read back only
+by the Touchstone-conversion step below, for the `Z0` header value and for optional de-embedding.
+
+### 9.2 — `combine_snp` → `combine_extend_snp.py`
+
+`scripts/combine_snp` (full file, the thin invocation wrapper):
+```bash
+#!/bin/bash
+~/venv/palace/bin/python ~/scripts/combine_extend_snp.py
+```
+Intentionally hardcoded to a particular venv/script path — `scripts/README.md` explicitly says
+"Please modify this as required for your environment." It takes **no arguments**: it relies on
+`combine_extend_snp.py`'s own `os.getcwd()`-based recursive directory walk, so it must be run from
+within (or above) the directory tree holding the Palace/Elmer output — which is exactly what
+`run_sim`/`run_elmer` do, since they run it right after the solve, from `sim_path`.
+
+**What `combine_extend_snp.py` actually does, traced through its real logic** (full source at
+`scripts/combine_extend_snp.py`, ~480 lines):
+
+1. **Discovery**: recursively walks the current directory tree, collecting every file literally
+   named `port-S.csv` (Palace) or `scalar_results.names` (Elmer) — a brute-force scan, which is
+   exactly why it tolerates Palace's AMR `iterationN/` subfolder nesting (one AMR iteration's
+   result sits one directory level deeper than the final result).
+2. **Per found file**: walks *upward* from the file's directory, up to 4 levels, looking for a
+   sibling `port_information.json`. If found: extracts each port's `Z0` into a Touchstone header
+   value (supports mixed port impedances as a space-separated list), and reads an optional
+   `"name"` field used as a filename fallback — needed because Elmer's native output directory is
+   always literally called `mesh`. If not found: defaults `Z0` to `"50"` and later prints a
+   warning.
+3. **Parsing**: `parse_palace_csv()` for `port-S.csv` (strips Palace's CSV formatting, enumerates
+   which `S[i][j]` columns are actually present — since only excited ports produce data) or
+   `parse_elmer_results()` for `scalar_results.names`+its paired data file (Elmer's "coupling
+   matrix" `cmf`/`cmf im` columns, converted from angular frequency in rad/s to GHz).
+4. **Assembling Touchstone rows**: for 2-port results specifically, swaps to `S[j][i]` ordering to
+   match Touchstone's traditional `S11 S21 S12 S22` convention (any other port count uses natural
+   row-major `S[i][j]` order). Any `(i,j)` pair with no data (an un-excited port, per §8) is padded
+   with `0.0`/`0.0` — this is exactly the "missing rows padded with zeros" behavior the user guide
+   documents.
+5. **Writing**: `<parentname>.s<N>p` (e.g. `mymodel.s2p`), written by hand (not via scikit-rf's
+   writer) as a header line `#  {freq_unit} S DB R {Z0_string}` followed by one
+   whitespace-separated data line per frequency.
+6. **DC extrapolation** (`extrapolate_to_DC()`): only if the Touchstone file has more than 20
+   frequency points *and* its lowest frequency is ≤1 GHz — Palace's frequency-domain solve cannot
+   go all the way to 0 Hz — this step re-reads the file via `skrf.Network` and calls scikit-rf's
+   `extrapolate_to_dc(points=None, dc_sparam=None, kind='cubic', coords='polar')`, writing the
+   result as `<basename>_dc.s<N>p`.
+7. **Port de-embedding** (`port_deembedding()`, marked **experimental** in `scripts/README.md`):
+   if `port_information.json` gave port `length`/`width`, computes a parasitic series inductance
+   per port using a flat-ribbon-inductor formula credited to F.E. Terman's *Radio Engineers
+   Handbook* (1945):
+   ```python
+   def flat_strip_inductance(length, width, thickness, unit):
+       return 2e-7 * length * unit * (
+           math.log(2*length/(width+thickness)) + 0.5 + 0.2235*(width+thickness)/length
+       )
+   ```
+   (`thickness=0` always — "Palace ports are 2D sheets with no thickness"), then cascades a
+   *negative* series inductor of that value onto each port of the network (via scikit-rf's
+   `media.inductor(...)` + `connect(...)`), writing the result as `<basename>_deembedded.s<N>p`.
+   Applied to both the plain and (if present) the `_dc`-extrapolated file.
+
+### 9.3 — End-to-end summary
+
+```
+model script
+  → simulation_setup.create_palace(excite_ports, settings)
+      writes config.json (Problem.Output = "output/<model_basename>") + <model>.msh + port_information.json
+      into <script_dir>/palace_model/<model_basename>_data/
+  → utilities.create_run_script(sim_path)
+      writes run_sim: "run_palace config.json" then "combine_snp"
+
+./run_sim  (or the model script's own start_simulation=True auto-run)
+  → run_palace config.json     [machine-specific, on PATH — repo's own dev version:
+                                 apptainer exec ~/palace.sif palace -np 8 config.json, Linux-only]
+      Palace writes output/<model_basename>/port-S.csv (+ other native files)
+  → combine_snp                [machine-specific, on PATH — repo's own dev version:
+                                 ~/venv/palace/bin/python ~/scripts/combine_extend_snp.py]
+      finds port-S.csv, cross-references port_information.json for Z0/geometry,
+      writes <model_basename>.s<N>p, then optionally _dc.s<N>p and _deembedded.s<N>p
+```
+
+---
+
+## 10. Creating field dumps
+
+In addition to S-parameters, Palace can write a full 3D field-solution dump (viewable in ParaView)
+at specific frequencies, via `settings['fdump']` — a list of frequencies in Hz, same shape as
+`fpoint` (§6):
+```python
+settings["fdump"] = [15e9]   # save a field dump at 15 GHz
+```
+(real usage: `workflow/palace_L2n0.py:84`; likewise `workflow/palace_butlermatrix_dump93.py:84`
+with `[93e9]`).
+
+Mechanically, this is threaded straight into `config.json`'s frequency sweep list
+(`util_simulation_setup.py:1870-1880`): each `fdump` frequency becomes its own `"Type": "Point"`
+entry in `Solver.Driven.Samples`, with **`"SaveStep": 1`** — as opposed to a plain `fpoint`
+discrete frequency, which gets `"SaveStep": 0`. `SaveStep: 1` is the flag that tells Palace to
+write field-solution output at that sample; gds2palace itself does not configure a separate output
+directory or file format for this — it's entirely Palace's own native field-dump mechanism,
+written under the same `Problem.Output` directory as the raw `port-S.csv` results (§9.1).
+
+Real usage from the user guide (`workflow/palace_L2n0.py`, an octagon inductor with via ports): with
+`settings["fdump"] = [15e9]`, opening Palace's resulting field-dump output in ParaView shows the
+current density distribution across the structure at 15 GHz — useful for sanity-checking where
+current is actually flowing (e.g. confirming skin-effect crowding, or spotting an unintended
+current path), not something derivable from S-parameters alone.
+
+**When to use it**: `fdump` is for visual/qualitative inspection of one or a few specific
+frequencies, not for production S-parameter extraction — don't add it to every frequency in a
+sweep (that multiplies Palace's output size and runtime for no benefit). Pick one or two
+frequencies of specific interest (a resonance, a suspected problem frequency), the way both real
+examples above do.
+
+---
+
+## 11. Elmer FEM — the alternative solver path
+
+Elmer FEM (https://www.elmerfem.org/) is a **second, independent, also-not-included** open-source
+FEM solver — a genuine alternative back end to Palace, not a pre/post-processing helper of it.
+`doc/userguide_md_format/gds2palace_workflow_userguide.md:785` is explicit: *"Elmer FEM is not
+distributed with gds2palace and must be installed separately... gds2palace needs to find two Elmer
+command-line tools: `ElmerGrid` (mesh conversion) and `ElmerSolver` (the solver itself)."* On
+Windows, gds2palace looks for `%ELMER_HOME%\bin\ElmerGrid.exe`; on Linux/macOS, both tools must be
+on `PATH`.
+
+Choosing Elmer instead of Palace is a **one-line change at the very end of an otherwise identical
+model script** — same `settings`, same ports, same `stackup_reader`/`gds_reader` calls:
+```python
+# Palace:
+config_name, data_dir = simulation_setup.create_palace(excite_ports, settings)
+utilities.create_run_script(sim_path)
+# Elmer:
+config_name, data_dir = simulation_setup.create_elmer(excite_ports, settings)
+utilities.create_elmer_run_script(sim_path, settings)
+```
+Both funnel into the same `create_model()` engine (§4), gated by `settings['elmer']`. Documented
+behavioral differences: Elmer's EM solver always solves *all* defined ports in one run (no
+per-excitation skip trick — though `voltage=0` ports are still just not excited/counted), has no
+adaptive-frequency-sweep equivalent, and (as of this writing) lacks sheet-resistor and composite-port
+support.
+
+There's a third mode, `create_elmer_thermal(settings)` — Elmer-only, no Palace equivalent,
+steady-state thermal (temperature) simulation using `heatsource`/`constanttemp` objects instead of
+EM ports. Out of scope for this document (see the user guide's "Using gds2palace with Elmer FEM for
+thermal simulation" chapter), but worth knowing it exists if you see `elmer_thermal` in the
+codebase.
+
+---
+
+## 12. Case study: the inductor synthesis examples
+
+There are **two** inductor-synthesis examples in `more_examples/`:
+
+1. `inductor_synthesis_no_external_library/synthesize_ihp_inductor_v3.py`
+2. `inductor_synthesis_using_pclab_library/synthesize_inductor_v11.py`
+
+**This chapter primarily analyzes #1**, which its own sibling README (in example #2's directory)
+cross-references as the more illustrative, self-contained example of gds2palace usage: *"For
+inductor synthesis in IHP SG13G2 without need for an external geometry library, see this
+example."* Example #2 delegates all geometry generation to a vendored, modified copy of the
+third-party [pcLab](https://github.com/dgrujic/pcLab) library — it's really a demo of "gds2palace +
+pcLab integration," not of gds2palace's own API surface. The differences are summarized in §12.5.
+
+### 12.1 — What's actually being "synthesized"
+
+**Geometry, not just EM verification of a pre-drawn part.** The script draws a symmetric
+octagonal spiral inductor directly to GDSII in Python (via `gdspy` primitives), for a whole grid of
+candidate `(turns N, width w, spacing s)` combinations, computing each candidate's required outer
+diameter `D` from a closed-form equation. gds2palace is used purely as the **EM solver backend
+inside an optimization loop** — called once per candidate geometry, many times per run — not to
+generate geometry itself.
+
+The example's own README states its 8-step "principle of operation" plainly:
+
+1. Determine candidate implementations via closed-form equations (required diameter for target L),
+   filtering out ones that are geometrically invalid or exceed a maximum diameter.
+2. Create GDSII layouts for every candidate (including ports + ground return).
+3. Run a **fast, low-order** FEM sweep over all candidates via gds2palace.
+4. Evaluate the top-N candidates by Q factor at the target frequency, and re-tune each toward the
+   target L.
+5. After a fixed number of re-tune iterations, pick the single best candidate and run a **full,
+   wideband, high-order** FEM sweep on it.
+6. Plot L and Q of that final candidate.
+7. Generate a final "production" GDSII with all the extra IHP SG13G2 OPDK layout features required
+   for a real PDK cell (no simulation-only geometry).
+
+### 12.2 — The optimization loop, precisely
+
+```
+closed-form estimate (Wheeler's equation) for D, per (N, w, s) combo
+  → draw candidate GDSII (with EM ports + ground-return frame)
+  → gds2palace EM sim, order=1 (fast/coarse)     [one create_palace() call per candidate]
+  → read back .s2p via skrf.Network, compute differential L/Q at target frequency
+  → keep the best-Q candidates, rescale D by sqrt(Ltarget / L_measured)
+  → redraw, gds2palace EM sim, order=2 (accurate)   [repeated a *fixed* number of iterations —
+                                                       not until convergence]
+  → pick the single winner
+  → gds2palace EM sim, wideband, order=2 (final)
+  → regenerate GDSII with production OPDK decoration layers, no ports/ground frame
+```
+
+**This is grid search + a fixed-point rescaling loop, not a real optimizer** — there is no
+`scipy.optimize` anywhere in either script. An agent asked to "improve convergence" here should
+understand this existing pattern before reaching for a different optimization algorithm.
+
+### 12.3 — How gds2palace is actually called (per candidate)
+
+The per-candidate model-creation function (`create_simulation_model()`) is a direct instance of
+§4's canonical pattern, just wrapped in a function and invoked in a loop:
+
+```python
+sim_path = utilities.create_sim_path(script_path, model_basename)
+simulation_ports = simulation_setup.all_simulation_ports()
+for portnumber in range(1, portcount+1):
+    simulation_ports.add_port(simulation_setup.simulation_port(
+        portnumber=portnumber, voltage=1, port_Z0=50,
+        source_layernum=200+portnumber,
+        from_layername=ground_layer_name, to_layername=port_layer_name,
+        direction='z'))
+
+layernumbers = metals_list.getlayernumbers()
+layernumbers.extend(simulation_ports.portlayers)
+allpolygons = gds_reader.read_gds(gds_filename, layernumbers, purposelist=[0],
+    metals_list=metals_list, preprocess=settings['preprocess_gds'],
+    merge_polygon_size=settings['merge_polygon_size'])
+
+settings['simulation_ports'] = simulation_ports
+settings['materials_list']   = materials_list
+settings['dielectrics_list'] = dielectrics_list
+settings['metals_list']      = metals_list
+settings['layernumbers']     = layernumbers
+settings['allpolygons']      = allpolygons
+settings['sim_path']         = sim_path
+settings['model_basename']   = model_basename
+
+excite_ports = simulation_ports.all_active_excitations()
+config_name, data_dir = simulation_setup.create_palace(excite_ports, settings)
+return config_name, data_dir
+```
+
+**Batch execution**: rather than running each candidate's Palace solve immediately, the script
+collects `config_name`s across a whole sweep phase and writes a single shell script
+(`simulate_all`) that `cd`s into each candidate's data directory and runs `run_palace <config.json>`
+for all of them **sequentially** — explicitly not parallelized, "to avoid asynchronous finish of
+simulation jobs" (a comment in the source) — then runs `combine_snp` once at the end and copies all
+resulting `.s*p` files back to the script directory. This whole batch is invoked via
+`subprocess.run(simulate_script_filename, shell=True)`, gated on `sys.platform.startswith("linux")`
+— **this script's Palace-invocation step only actually runs on Linux**, consistent with §5.
+
+**Results are read back entirely outside gds2palace's own API** — using `skrf.Network` directly on
+the Touchstone file `combine_snp` produced, then a script-local `get_diff_model()` function converts
+the raw 1/2/3-port Z or Y matrix into a scalar differential inductance/resistance/Q (handling the
+optional floating center-tap port by nulling it out algebraically). **There is no gds2palace-
+provided S-parameter-to-L/Q utility** — every example that needs to "close the loop" from simulation
+results back into a design decision re-implements this kind of post-processing itself.
+
+### 12.4 — Non-obvious patterns worth knowing about (for an agent working on similar scripts)
+
+- **No result caching or reuse** — every run deletes prior `palace_model/`, `*.s?p`, `*.gds`
+  output and resimulates everything from scratch (`cleanup_old_data=True` by default). No
+  memoization of previously-seen `(N,w,s,D)` combinations, even within a single run.
+- **Runtime cost is a first-class, explicitly-acknowledged concern**: the initial sweep alone can
+  spawn dozens of full 3D-meshed Palace solves (e.g. 2 turn-counts × 8 widths × 4 spacings = up to
+  64 combinations, filtered by geometric validity). The script gives the user a 10-second
+  `Ctrl+C`-to-abort window before committing to the full batch.
+- **FEM order is deliberately varied by phase** — order 1 (fast, less accurate) for the broad
+  sweep, bumped to order 2 before the fine-tune loop and kept at 2 for the final wideband run —
+  the standard speed/accuracy tradeoff pattern in this codebase (§7).
+- **A "faked DC" frequency point** (a low-but-nonzero frequency, e.g. 100 MHz, explicitly commented
+  "do not change") stands in for true DC inductance, since a real 0 Hz EM solve is ill-posed — used
+  only internally to compute the diameter-rescale factor, not reported to the user.
+- **A center-tap port, when present in the drawn geometry, is deliberately excluded from EM
+  excitation** during the sweep/fine-tune phases (2-port simulation only, tap left floating) and
+  only added back for the final model — meaning intermediate phases produce `.s2p` files while the
+  final phase produces `.s3p`. An agent debugging a "file not found" error against one of these
+  scripts should check which phase it's in before assuming a bug.
+- **Sanity filtering happens before any simulation runs at all**: a candidate whose crossover
+  geometry would force physically-invalid via placement, or whose diameter exceeds the configured
+  maximum, is dropped from the candidate list before any GDSII is even drawn for it — so the actual
+  number of Palace runs in a sweep phase is data-dependent, not simply the full cross-product of
+  the configured ranges.
+- **The deliverable is a real, PDK-compliant GDSII cell**, not just simulation artifacts: the final
+  step regenerates the winning geometry a second time *without* the simulation-only ports/ground
+  frame, adding the IHP SG13G2 OPDK decoration layers (`nofill`/`PWell.block`/`NoRCX`/`IND`
+  purposes) that a real PDK cell requires, saved with a `final_` prefix alongside its
+  `final_`-prefixed verified Touchstone file.
+
+### 12.5 — How the pcLab-based variant (example #2) differs
+
+"No external library" specifically means *no dependency on pcLab* — the SG13G2-specific spiral
+drawing, via-array drawing, port/ground-frame drawing, and OPDK decoration that pcLab (plus its
+`pin2port`/`ihp_sg13_features` helper modules) would otherwise provide are all reimplemented
+directly with `gdspy` primitives in example #1's single script. Concretely, pcLab (vendored at
+`more_examples/inductor_synthesis_using_pclab_library/pclab/`) provides:
+
+- A generic technology-rule engine (`pclTech.Technology("SG13G2.tech")`) that geometry classes
+  query instead of hard-coded via-rule constants.
+- Reusable, technology-agnostic inductor-shape classes (`pclInductor.py`'s `inductorSym`,
+  `inductorSymCT`) instead of a single bespoke `symmetric_octa_IHP()` function.
+- A generic pin-to-EM-port converter (`pin2port.py`'s `gds_pin2viaport(...)`) that auto-detects
+  which side of the bounding box each labeled pin sits on and synthesizes port/frame geometry from
+  that, geometrically, rather than example #1's parametric-formula approach.
+- A separate, explicit OPDK-decoration post-processing step (`ihp_sg13_features.py`'s
+  `gds_add_sg13_features(...)`) rather than example #1's approach of doing decoration inline as
+  part of the main drawing function.
+
+The optimization-loop code itself (`create_simulation_model`, `run_models_from_list`,
+`get_best_results`, `get_diff_model`, `calc_resize_factor`, the overall sweep→finetune→final flow)
+is essentially identical between the two scripts — **the only real difference is in how the
+geometry gets drawn**, not in how gds2palace gets used.
+
+---
+
+## 13. Quick checklist — writing a new model script
+
+1. `sys.path.insert(...)` + `from gds2palace import *` (only needed if running against the in-repo
+   source rather than an installed package).
+2. `utilities.get_script_path/get_basename/create_sim_path` → `sim_path`.
+3. Build `settings = {}` with at minimum `unit`, `margin`, `fstart`/`fstop`/`fstep`,
+   `refined_cellsize` (§6).
+4. Define ports via `simulation_setup.all_simulation_ports()` +
+   `simulation_ports.add_port(simulation_setup.simulation_port(...))` (§8) — remember `voltage=0`
+   defines-but-doesn't-excite a port.
+5. `stackup_reader.read_substrate(XML_filename)` → `materials_list, dielectrics_list, metals_list`
+   (§3 covers the file format and how to generate/edit one programmatically via `stackup_writer`).
+6. `layernumbers = metals_list.getlayernumbers(); layernumbers.extend(simulation_ports.portlayers)`.
+7. `gds_reader.read_gds(gds_filename, layernumbers, purposelist=[0], metals_list=metals_list, ...)`
+   → `allpolygons`.
+8. Stuff `simulation_ports`, `materials_list`, `dielectrics_list`, `metals_list`, `layernumbers`,
+   `allpolygons`, `sim_path`, `model_basename` into `settings`.
+9. `excite_ports = simulation_ports.all_active_excitations()`, then
+   `simulation_setup.create_palace(excite_ports, settings)` (or `create_elmer(...)`).
+10. `utilities.create_run_script(sim_path)` (or `create_elmer_run_script(sim_path, settings)`).
+11. To actually simulate: a working `run_palace` (Palace binary via Apptainer/Spack, on Linux/WSL)
+    and `combine_snp` must exist on `PATH` in the execution environment — this repo does not, and
+    cannot, provide those. Do not attempt to invoke `palace`/`ElmerSolver` directly; go through the
+    generated `run_sim`/`run_elmer` wrapper, which in turn goes through those two `PATH`-resolved
+    commands.
+12. Simulation results land as `<model_basename>.s<N>p` (+ optionally `_dc`/`_deembedded` variants)
+    next to `port-S.csv`, produced by `combine_snp` → `combine_extend_snp.py` (§9) — read them with
+    `skrf.Network(...)`, same as every example in this repo does; there is no gds2palace-native
+    result-reading API.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,9 @@
 
 This is an (incomplete) list of changes and new features.
 
+## 05-September-2026
+Elmer EM (S-parameter) simulations can now actually write field-dump data when `fdump` frequencies are set — this was silently doing nothing before. Fixed a crash when `fdump` was used without also specifying a frequency sweep (`fstart`/`fstop`), for both Palace and Elmer output. Fixed the generated Elmer run script on Windows, which used Linux-only `mpirun`/bash syntax and never actually worked there.
+
 ## 01-September-2026
 Fixed a crash in `resolve_derived_layers()`: `gdspy.boolean()` raises `IndexError` when called with an empty operand (e.g. a resistor recognition layer with no polygons in the current cell), which previously aborted the whole GDSII read. The boolean fold now short-circuits using the OR/AND/NOT identity instead whenever either operand is empty. Same fix applied to openems_ihp_sg13g2's independent copy of this reader.
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -9,6 +9,8 @@ Fixed two related bugs in mesh generation that caused `IndexError`/`Could not cr
 
 Vias now also get surface physical groups for their lateral (vertical) side faces, not just a volume — useful for Elmer thermal mesh visualization in Paraview. Top/bottom mating faces stay attributed to the metal layers the via connects to, to avoid a false "conductor layers touch" error.
 
+Fixed Elmer EM simulations silently re-solving the same frequency twice: `write_elmer_frequencies()` combined the swept range with `fpoint`/`fdump` values without checking for overlap, so a frequency that happened to appear in both the sweep and `fpoint`/`fdump` landed on two separate lines of `frequencies.dat` — and Elmer's "Scanning" simulation solves every line as an independent full simulation task, addressed by index, not by value. The combined list is now de-duplicated before being written.
+
 ## 05-September-2026
 Elmer EM (S-parameter) simulations can now actually write field-dump data when `fdump` frequencies are set — this was silently doing nothing before. Fixed a crash when `fdump` was used without also specifying a frequency sweep (`fstart`/`fstop`), for both Palace and Elmer output. Fixed the generated Elmer run script on Windows, which used Linux-only `mpirun`/bash syntax and never actually worked there.
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,13 @@
 
 This is an (incomplete) list of changes and new features.
 
+## 06-September-2026
+Elmer thermal simulations can now use a direct linear solver (UMFPACK) instead of the iterative BiCGStabl solver, via `settings['iterative']=False` — useful when the iterative solver fails to converge on a large conductivity contrast between materials. Loosened the default iterative solver's convergence tolerance and raised its iteration cap, since the previous defaults could fail to converge on some models.
+
+Fixed two related bugs in mesh generation that caused `IndexError`/`Could not create line` crashes on complex geometry involving OpenCASCADE boolean fragments: `is_vertical_surface()` used a threshold check (`int(abs(n))==0`) that misclassified almost every reconstructed horizontal face as vertical, and `get_surface_orientation()` computed a face's normal from only its first 3 boundary vertices, which could be near-collinear after a boolean fragment/union rebuilt the face. Both are now more robust (proper threshold, and Newell's method over all boundary vertices).
+
+Vias now also get surface physical groups for their lateral (vertical) side faces, not just a volume — useful for Elmer thermal mesh visualization in Paraview. Top/bottom mating faces stay attributed to the metal layers the via connects to, to avoid a false "conductor layers touch" error.
+
 ## 05-September-2026
 Elmer EM (S-parameter) simulations can now actually write field-dump data when `fdump` frequencies are set — this was silently doing nothing before. Fixed a crash when `fdump` was used without also specifying a frequency sweep (`fstart`/`fstop`), for both Palace and Elmer output. Fixed the generated Elmer run script on Windows, which used Linux-only `mpirun`/bash syntax and never actually worked there.
 

--- a/doc/userguide_md_format/gds2palace_workflow_userguide.md
+++ b/doc/userguide_md_format/gds2palace_workflow_userguide.md
@@ -11,6 +11,7 @@ Document version: 2026-08-17
 [Required software and Python modules](#required-software-and-python-modules)  
 &ensp;[Recommended installation of gds2palace as Python module](#recommended-installation-of-gds2palace-as-python-module)  
 &ensp;[Alternative, no longer recommended: local gds2palace directory](#alternative-no-longer-recommended-local-gds2palace-directory)  
+&ensp;[External tools (not Python modules)](#external-tools-not-python-modules)  
 [Installing AWS Palace](#installing-aws-palace)  
 &ensp;[Installing the Palace solver using Apptainer](#installing-the-palace-solver-using-apptainer)  
 &ensp;[Installing the Palace solver using spack package manager](#installing-the-palace-solver-using-spack-package-manager)  
@@ -135,6 +136,13 @@ This virtual environment with installed dependencies can be used to run gds2pala
 ```
 source ~/venv/palace/bin/activate
 ```
+
+### External tools (not Python modules)
+
+Two more tools are needed for parts of the workflow, but are not installed via pip:
+
+- [ParaView](https://www.paraview.org/) — to view field-dump output (Palace/Elmer EM) and Elmer thermal result files.
+- An MPI implementation — only needed for multi-process Elmer runs (`settings['ELMER_MPI_THREADS']`, see chapter "Installing Elmer FEM"). Use OpenMPI or MPICH on Linux/macOS; on Windows, install [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi).
 
 ## Installing AWS Palace 
 
@@ -786,6 +794,8 @@ Elmer FEM is not distributed with gds2palace and must be installed separately, s
 
 - **Windows:** set the environment variable `ELMER_HOME` to your Elmer install directory. gds2palace looks for `%ELMER_HOME%\bin\ElmerGrid.exe`.
 - **Linux/macOS:** make sure `ElmerGrid` and `ElmerSolver` are available on your `PATH`.
+
+If you use `settings['ELMER_MPI_THREADS']` to run Elmer across multiple processes, you also need an MPI implementation installed (see "External tools (not Python modules)" above) — on Windows this is Microsoft MPI, providing the `mpiexec`/`mpirun` launcher the generated `run_elmer` script uses.
 
 ### From a Palace model to an Elmer model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.9"
 dependencies = [
     "gdspy>1.6.0",
     "gmsh",
+    "numpy",
 ]
 
 [project.urls]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,15 +1,13 @@
 These scripts support the workflow when using gds2palace with the AWS Palace solver. Include the script folder to your PATH.
 
-**build_pypi_readme.py** regenerates `README_pypi.md` at the repo root from `README.md`, rewriting relative `./doc/...` links to absolute GitHub URLs so images render on the PyPI package page. Run this before `python -m build`, from the repo root: `python scripts/build_pypi_readme.py`
+## Running Palace
 
 **combine_extend_snp.py** is a script to search for Palace S-parameter result files (port-S.csv) and convert them to the standard Touchstone SnP file format. The script will start searching at the current directory, and search through all directory levels below. If S-parameters include low frequency data, it will also run DC data extrapolation to provide a 0 Hz result, and save that into another file with suffix "_dc.snp"
 If port geometry information is available, as created by the latest version of gds2palace, an additional file with de-embedded results is created. This is an experimental feature, it adds port de-embedding for lumped ports by cascading negative series L at each port.
 
-**palace_summary.py** prints a human-readable summary of AWS Palace solver results (degrees of freedom, mesh size, simulation time, peak RAM, and adaptive-mesh-refinement error indicators) for a completed or in-progress run. Run it with no arguments from inside the `<model>_data` directory that contains `config.json`, or pass a path as an argument. That path is searched recursively for every `<model>_data` directory (identified by containing a `config.json`) some levels below it, and a summary is printed for each one found - handy for pointing it at a folder of examples and getting a summary of every run inside. The model base name for each run is auto-derived from its directory name (stripping the trailing `_data`); `--model-basename` overrides this, but only applies when exactly one run directory is found. Exits with a nonzero status if any run has no results yet, so it can be chained after `run_palace` in a script to detect whether simulation(s) actually finished.
-
 **combine_snp** is the shell script to run the combine_extend_snp.py Python script, if a Python venv named "palace" exists will all the Python libraries required for the gds2palace workflow, including scikit-rf. Please modify this as required for your environment.
 
-**run_palace** is the script that was used during development to run Palace from an apptainer (container) file ~/palace.sif, using 8 core parallel simulation. Please modify this as required for your environment. A description how to create the Palace apptainer (container) for Palace can be found here: https://awslabs.github.io/palace/stable/install/
+**run_palace** is the script that was used during development to run Palace from an apptainer (container) file ~/palace.sif, using 8 core parallel simulation. Please modify this as required for your environment.  
 
 If you prefer to install and run Palace in a different way, no problem! The gds2palace workflow creates the input files for Palace, and it is entirely your choice how you run the simulator with these model files, local or on a sophisticated HPC cluster.
 
@@ -26,3 +24,24 @@ Similar to run_palace, this script takes one parameter: the Palace config file *
 Given the config.json model file, that entire directory (including mesh) is copied to the remote machine, simulated there by running the server's run_sim, and results are copied back when simulation is finished.
 
 This script was successfully used to send simulation from setupEM + gds2palace on MacOS to an Ubuntu simulation server running Ubuntu 24.02.  On the remote system, script run_sim (no parameters) is executed to start Palace for model config.json in the current directory 
+
+
+## Show simulation log / report
+
+**palace_summary.py** prints a human-readable summary of AWS Palace solver results for a completed or in-progress run. 
+
+-  degrees of freedom
+- mesh size
+- simulation time
+- peak RAM
+- adaptive-mesh-refinement error indicators 
+
+Run `palace_summary.py` with no arguments from inside the `<model>_data` directory that contains `config.json`, or pass a path as an argument. That path is searched recursively for every `<model>_data` directory (identified by containing a `config.json`).  
+
+The model base name for each run is auto-derived from its directory name, or you can override by `--model-basename`. 
+
+palace_summary.py exits with a nonzero status if any run has no results yet, so it can be chained after `run_palace` in a script to detect whether simulation(s) actually finished.
+
+## Other Utilities
+
+**build_pypi_readme.py** regenerates `README_pypi.md` at the repo root from `README.md`, rewriting relative `./doc/...` links to absolute GitHub URLs so images render on the PyPI package page. Run this before `python -m build`, from the repo root: `python scripts/build_pypi_readme.py`

--- a/scripts/combine_extend_snp.py
+++ b/scripts/combine_extend_snp.py
@@ -310,32 +310,41 @@ def port_deembedding (snp_filename, port_info_available, port_info_data):
 
 
 
-workdir = os.getcwd()
-found_datafiles = []
+def main():
+    global found_datafiles
 
-# work recursively through directories
-traverse_directories(workdir)
+    workdir = os.getcwd()
+    found_datafiles = []
 
-# evaluate the found data files
-for found_filename in found_datafiles:
+    # work recursively through directories
+    traverse_directories(workdir)
+
+    # evaluate the found data files
+    for found_filename in found_datafiles:
+        _process_datafile(found_filename)
+
+
+def _process_datafile(found_filename):
     # print(str(f))
 
     # Before we evaluate S-parameters, also check if we have a file port_information.json
+    # Search upward from the data file's directory, since it can be one level
+    # further down for AMR iteration folders (.../output/<model>/iterationN/port-S.csv)
+    # than for a normal run (.../output/<model>/port-S.csv). Capped at a small fixed
+    # depth so we never wander off into unrelated directories further up the tree.
     port_info_available = False
-    # Get the directory two levels up
-    two_up_dir = os.path.abspath(os.path.join(os.path.dirname(found_filename), "..", ".."))
-    # Possible full filename for port_information.json
-    port_info_filename = os.path.join(two_up_dir, "port_information.json")
-    
-    # Check if it exists
-    if not os.path.isfile(port_info_filename):
-        # let's try one level above
-        one_up_dir = os.path.abspath(os.path.join(os.path.dirname(found_filename), ".."))
-        # Possible full filename for port_information.json
-        port_info_filename = os.path.join(one_up_dir, "port_information.json")
+    MAX_LEVELS_UP = 4
+    search_dir = os.path.abspath(os.path.dirname(found_filename))
+    port_info_filename = None
+    for _ in range(MAX_LEVELS_UP):
+        search_dir = os.path.abspath(os.path.join(search_dir, ".."))
+        candidate = os.path.join(search_dir, "port_information.json")
+        if os.path.isfile(candidate):
+            port_info_filename = candidate
+            break
 
-    # If we found the port file one or two levels above
-    if os.path.isfile(port_info_filename):
+    # If we found the port file within MAX_LEVELS_UP directories above
+    if port_info_filename is not None:
         print(f"Found extra file with port information: {port_info_filename}")
 
         # Load the JSON data
@@ -462,4 +471,8 @@ for found_filename in found_datafiles:
             fn = dc_extrapolated_filename + '.s' + str(num_ports) + 'p'
             if os.path.isfile(fn):
                 port_deembedding (fn, port_info_available, port_info_data)
-       
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/palace_summary.py
+++ b/scripts/palace_summary.py
@@ -93,7 +93,6 @@ def _read_error_indicators(dir_path):
         return {
             'norm': float(fields['Norm']),
             'maximum': float(fields['Maximum']),
-            'mean': float(fields['Mean']),
         }
     except (KeyError, ValueError):
         return None
@@ -271,7 +270,7 @@ def build_results_summary(run_path, model_basename):
         if errors:
             lines.append(
                 f"Error indicator    : Norm={_format_sci(errors['norm'])}  "
-                f"Max={_format_sci(errors['maximum'])}  Mean={_format_sci(errors['mean'])}"
+                f"Max={_format_sci(errors['maximum'])}"
             )
         lines.append("=" * 40)
         return "\n".join(lines), None
@@ -279,7 +278,7 @@ def build_results_summary(run_path, model_basename):
     # Adaptive mesh refinement: one row per iteration subfolder, plus the root as "Final"
     rows = _collect_amr_rows(output_dir, iteration_dirs)
 
-    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean",
+    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max",
                "Max dS", "Time", "Peak RAM"]
     table_rows = []
     for label, summary, errors, delta_s in rows:
@@ -291,7 +290,6 @@ def build_results_summary(run_path, model_basename):
             _format_int(summary.get('mesh_elements')),
             _format_sci(errors.get('norm')),
             _format_sci(errors.get('maximum')),
-            _format_sci(errors.get('mean')),
             _format_delta(delta_s),
             _format_duration(summary.get('duration_s')),
             _format_ram(summary.get('peak_ram_mb')),

--- a/scripts/palace_summary.py
+++ b/scripts/palace_summary.py
@@ -28,7 +28,14 @@ import sys
 import json
 import csv
 import re
+import math
+import cmath
 import argparse
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+from combine_extend_snp import parse_palace_csv
 
 __version__ = "1.0"
 
@@ -91,6 +98,70 @@ def _read_error_indicators(dir_path):
         }
     except (KeyError, ValueError):
         return None
+
+
+def _read_port_s_data(dir_path):
+    """Parse dir_path/port-S.csv (if present) into (freq_list, S_dB_list,
+    S_arg_list, num_ports) using combine_extend_snp's CSV parser, or None if
+    the file is missing, unfinished, or malformed (e.g. a still-running pass).
+    """
+    path = os.path.join(dir_path, 'port-S.csv')
+    if not os.path.isfile(path):
+        return None
+    freq, S_dB, S_arg = [], [], []
+    try:
+        num_ports, _freq_unit = parse_palace_csv(path, freq, S_dB, S_arg)
+    except (OSError, ValueError, IndexError, KeyError):
+        return None
+    if not freq:
+        return None
+    return freq, S_dB, S_arg, num_ports
+
+
+def _max_delta_s(prev_data, curr_data):
+    """Max |S_curr - S_prev| across all ports and frequencies common to both
+    passes, mirroring HFSS's per-pass Max Delta S. Returns None if either
+    pass has no port-S data, or the two use different port counts.
+    """
+    if prev_data is None or curr_data is None:
+        return None
+    freq_p, dB_p, arg_p, ports_p = prev_data
+    freq_c, dB_c, arg_c, ports_c = curr_data
+    if ports_p != ports_c:
+        return None
+
+    max_delta = 0.0
+    found_any = False
+    for idx in range(min(len(freq_p), len(freq_c))):
+        for key in set(dB_p[idx]) & set(dB_c[idx]):
+            try:
+                Sp = cmath.rect(10 ** (float(dB_p[idx][key]) / 20.0), math.radians(float(arg_p[idx][key])))
+                Sc = cmath.rect(10 ** (float(dB_c[idx][key]) / 20.0), math.radians(float(arg_c[idx][key])))
+            except ValueError:
+                continue
+            found_any = True
+            max_delta = max(max_delta, abs(Sc - Sp))
+    return max_delta if found_any else None
+
+
+def _collect_amr_rows(output_dir, iteration_dirs):
+    """One row per AMR iteration subfolder, plus the root output_dir as
+    'Final': (label, palace_json_dict_or_None, error_indicators_dict_or_None,
+    max_delta_s_vs_previous_row_or_None).
+    """
+    dirs_in_order = list(iteration_dirs) + [output_dir]
+    labels = [os.path.basename(d) for d in iteration_dirs] + ["Final"]
+
+    rows = []
+    prev_port_s = None
+    for label, d in zip(labels, dirs_in_order):
+        summary = _read_palace_json(d)
+        errors = _read_error_indicators(d)
+        port_s = _read_port_s_data(d)
+        delta_s = _max_delta_s(prev_port_s, port_s)
+        rows.append((label, summary, errors, delta_s))
+        prev_port_s = port_s
+    return rows
 
 
 def _find_run_dirs(search_root):
@@ -156,14 +227,32 @@ def _format_sci(x):
     return 'n/a' if x is None else f"{x:.3e}"
 
 
+def _format_delta(x):
+    return 'n/a' if x is None else f"{x:.4f}"
+
+
+def _save_convergence_summary(run_path, summary_text):
+    """Save the AMR summary table alongside the run's config.json /
+    port_information.json, so it's available on disk without re-running the
+    simulation or scrolling back through this script's console output.
+    """
+    try:
+        with open(os.path.join(run_path, "mesh_convergence_summary.txt"), "w", encoding="utf-8") as f:
+            f.write(summary_text + "\n")
+    except OSError:
+        pass
+
+
 def build_results_summary(run_path, model_basename):
-    """Return a formatted multi-line summary of Palace results found under run_path,
-    or an explanatory message if nothing is there yet.
+    """Return (text, rows) for the Palace results found under run_path: a
+    formatted multi-line summary (or an explanatory message if nothing is
+    there yet), and the AMR rows from _collect_amr_rows() if this run used
+    adaptive mesh refinement, else None.
     """
     output_dir = _find_output_dir(run_path, model_basename)
     if not os.path.isdir(output_dir):
         return (f"No Palace results found yet (expected output directory: {output_dir}) "
-                 "-- has the simulation finished?")
+                 "-- has the simulation finished?"), None
 
     iteration_dirs = _list_iteration_dirs(output_dir)
 
@@ -172,7 +261,7 @@ def build_results_summary(run_path, model_basename):
         errors = _read_error_indicators(output_dir)
         if summary is None:
             return (f"No palace.json found yet in {output_dir} "
-                     "-- has the simulation finished?")
+                     "-- has the simulation finished?"), None
         lines = [
             f"=== Simulation results: {model_basename} ===",
             f"Degrees of freedom : {_format_int(summary['dof'])}",
@@ -186,16 +275,15 @@ def build_results_summary(run_path, model_basename):
                 f"Max={_format_sci(errors['maximum'])}  Mean={_format_sci(errors['mean'])}"
             )
         lines.append("=" * 40)
-        return "\n".join(lines)
+        return "\n".join(lines), None
 
     # Adaptive mesh refinement: one row per iteration subfolder, plus the root as "Final"
-    rows = [(os.path.basename(it_dir), _read_palace_json(it_dir), _read_error_indicators(it_dir))
-            for it_dir in iteration_dirs]
-    rows.append(("Final", _read_palace_json(output_dir), _read_error_indicators(output_dir)))
+    rows = _collect_amr_rows(output_dir, iteration_dirs)
 
-    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean", "Time", "Peak RAM"]
+    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean",
+               "Max dS", "Time", "Peak RAM"]
     table_rows = []
-    for label, summary, errors in rows:
+    for label, summary, errors, delta_s in rows:
         summary = summary or {}
         errors = errors or {}
         table_rows.append([
@@ -205,6 +293,7 @@ def build_results_summary(run_path, model_basename):
             _format_sci(errors.get('norm')),
             _format_sci(errors.get('maximum')),
             _format_sci(errors.get('mean')),
+            _format_delta(delta_s),
             _format_duration(summary.get('duration_s')),
             _format_ram(summary.get('peak_ram_mb')),
         ])
@@ -224,7 +313,57 @@ def build_results_summary(run_path, model_basename):
     for row in table_rows:
         lines.append(fmt_row(row))
     lines.append("=" * len(header_line))
-    return "\n".join(lines)
+    summary_text = "\n".join(lines)
+    _save_convergence_summary(run_path, summary_text)
+    return summary_text, rows
+
+
+def plot_convergence(rows, model_basename, out_path):
+    """Render an HFSS-style convergence chart (error-indicator norm and max
+    delta-S vs. AMR iteration, log-y) for the rows built by
+    _collect_amr_rows(), and save it to out_path. Returns out_path.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    indices = list(range(len(rows)))
+    labels = [label for label, _summary, _errors, _delta_s in rows]
+
+    norm_x, norm_y = [], []
+    for i, (_label, _summary, errors, _delta_s) in zip(indices, rows):
+        if errors and errors.get('norm') is not None:
+            norm_x.append(i)
+            norm_y.append(errors['norm'])
+
+    delta_x, delta_y = [], []
+    for i, (_label, _summary, _errors, delta_s) in zip(indices, rows):
+        if delta_s is not None:
+            delta_x.append(i)
+            delta_y.append(delta_s)
+
+    fig, ax1 = plt.subplots(figsize=(7, 4.5))
+    ax1.set_xlabel("AMR iteration")
+    ax1.set_xticks(indices)
+    ax1.set_xticklabels(labels, rotation=45, ha='right')
+
+    ax1.set_ylabel("Error indicator norm", color='tab:blue')
+    ax1.set_yscale("log")
+    line1, = ax1.plot(norm_x, norm_y, marker='o', color='tab:blue', label='Error norm')
+    ax1.tick_params(axis='y', labelcolor='tab:blue')
+
+    ax2 = ax1.twinx()
+    ax2.set_ylabel("Max |ΔS|", color='tab:red')
+    ax2.set_yscale("log")
+    line2, = ax2.plot(delta_x, delta_y, marker='s', color='tab:red', label='Max ΔS')
+    ax2.tick_params(axis='y', labelcolor='tab:red')
+
+    ax1.legend(handles=[line1, line2], loc='upper right')
+    fig.suptitle(f"AMR convergence: {model_basename}")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    return out_path
 
 
 # --------------------------
@@ -270,6 +409,13 @@ def main():
              "(default: derived from the run directory name by stripping a "
              "trailing '_data' suffix)"
     )
+    parser.add_argument(
+        "--plot", action="store_true",
+        help="for each run that used adaptive mesh refinement, also render a "
+             "convergence chart (error-indicator norm and max delta-S vs. "
+             "AMR iteration, HFSS-style) and save it as convergence.png in "
+             "that run's directory (requires matplotlib)"
+    )
     args = parser.parse_args()
 
     search_path = os.path.abspath(args.search_path)
@@ -303,11 +449,19 @@ def main():
     for run_path, model_basename in zip(run_dirs, basenames):
         if len(run_dirs) > 1:
             print(f"----- {run_path} -----")
-        summary = build_results_summary(run_path, model_basename)
+        summary, rows = build_results_summary(run_path, model_basename)
         print(summary)
         print()
         if summary.startswith("No Palace results found yet") or summary.startswith("No palace.json found yet"):
             any_incomplete = True
+
+        if args.plot:
+            if rows:
+                out_path = os.path.join(run_path, "convergence.png")
+                plot_convergence(rows, model_basename, out_path)
+                print(f"Convergence plot saved to: {out_path}\n")
+            else:
+                print(f"--plot requested but no AMR iterations found for {model_basename}, skipping.\n")
 
     sys.exit(1 if any_incomplete else 0)
 

--- a/scripts/palace_summary.py
+++ b/scripts/palace_summary.py
@@ -92,7 +92,6 @@ def _read_error_indicators(dir_path):
     try:
         return {
             'norm': float(fields['Norm']),
-            'minimum': float(fields['Minimum']),
             'maximum': float(fields['Maximum']),
             'mean': float(fields['Mean']),
         }

--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.4.2"   # version of gds2palace
+__version__ = "0.4.3"   # version of gds2palace
 

--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.4.1"   # version of gds2palace
+__version__ = "0.4.2"   # version of gds2palace
 

--- a/workflow/gds2palace/util_elmer.py
+++ b/workflow/gds2palace/util_elmer.py
@@ -62,21 +62,28 @@ def write_elmer_frequencies (elmer_freq_file,
         return num_frequencies  
 
 def write_elmer_physics_file (unit,
-                              elmer_physics_file, 
-                              num_frequencies, 
-                              Elmer_materials, 
+                              elmer_physics_file,
+                              num_frequencies,
+                              Elmer_materials,
                               Elmer_bodies,
                               Elmer_boundaries,
                               Elmer_ports,
                               PEC_boundaries,
                               PML_boundaries,
-                              PMC_boundaries):
-        
-        with open(elmer_physics_file, "w") as f:  
-            
-            # specify storage of dump files
-            item = '! Dont save vtu files (other options: "after timestep", "after all")\n'
-            item = item + 'Solver 3 :: Exec Solver = String "never"\n\n'
+                              PMC_boundaries,
+                              f_dump_list=None):
+
+        with open(elmer_physics_file, "w") as f:
+
+            # specify storage of dump files: only when fdump frequencies were requested,
+            # since Elmer's "Scanning" simulation has no per-sample SaveStep like Palace -
+            # this dumps fields at every solved frequency, not just the fdump-selected ones
+            dump_requested = bool(f_dump_list)
+            if dump_requested:
+                item = '! Save vtu field dump files at every solved frequency (other options: "after timestep", "after all")\n'
+            else:
+                item = '! Dont save vtu files (other options: "after timestep", "after all")\n'
+            item = item + f'Solver 3 :: Exec Solver = String "{"Always" if dump_requested else "never"}"\n\n'
             f.write(item + '\n')
 
             # frequency block that references output file frequencies.dat

--- a/workflow/gds2palace/util_elmer.py
+++ b/workflow/gds2palace/util_elmer.py
@@ -392,15 +392,28 @@ def write_case_and_solver_files (targetdir, order, iterative, ELMER_MPI_THREADS=
 
 def write_elmer_thermal_file (unit,
                                 elmer_thermal_file,
-                                Elmer_materials, 
+                                Elmer_materials,
                                 Elmer_bodies,
                                 Elmer_boundaries,
                                 Elmer_body_forces,
-                                Elmer_thermal_boundaryconditions):
-    
+                                Elmer_thermal_boundaryconditions,
+                                iterative=True):
+
     with open(elmer_thermal_file, "w") as f:
 
         vtu_file = '../thermal_results.vtu'
+
+        if iterative:
+            linear_system_block = '''Linear System Solver = Iterative
+Linear System Iterative Method = BiCGStabl
+Linear System Max Iterations = 100000
+Linear System Convergence Tolerance = 1.0e-7
+Linear System Preconditioning = ILU1'''
+        else:
+            # MUMPS is not available in the Windows Elmer build - UMFPACK ships
+            # with Elmer on all platforms and needs no extra solver-specific options
+            linear_system_block = '''Linear System Solver = Direct
+Linear System Direct Method = umfpack'''
 
         header1=f'''
 Check Keywords "warn"
@@ -430,11 +443,7 @@ Solver 1
 Equation = Heat Equation
 Procedure = "HeatSolve" "HeatSolver"
 Variable = Temperature
-Linear System Solver = Iterative
-Linear System Iterative Method = BiCGStabl
-Linear System Max Iterations = 2500
-Linear System Convergence Tolerance = 1.0e-10
-Linear System Preconditioning = ILU1
+{linear_system_block}
 Steady State Convergence Tolerance = 1.0e-5
 End        
 

--- a/workflow/gds2palace/util_elmer.py
+++ b/workflow/gds2palace/util_elmer.py
@@ -52,6 +52,24 @@ def write_elmer_frequencies (elmer_freq_file,
 
             # sort and write to file
             frequency_list.sort()
+
+            # De-duplicate: Elmer's "Scanning" simulation solves one full pass per
+            # line of frequencies.dat, addressed by index - a duplicate value on two
+            # lines (whether bit-identical, or merely rounding to the same text
+            # below) means Elmer silently re-solves the same physical frequency
+            # twice. Coincidental overlap between the sweep, fpoint, and fdump (or
+            # float drift from repeated "f = f + fstep" additions landing next to a
+            # user-specified value) is common, so dedupe on the same 3-significant-
+            # digit text written below rather than exact float equality.
+            deduped = []
+            seen = set()
+            for freq in frequency_list:
+                key = f"{freq:.3e}"
+                if key not in seen:
+                    seen.add(key)
+                    deduped.append(freq)
+            frequency_list = deduped
+
             for n, freq in enumerate(frequency_list):
                 freqfile.write(f"{n+1}  {freq:.3e}\n")
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1111,7 +1111,11 @@ def create_model (excite_ports, settings):
         # Get the boundary of the surface
         boundary_lines  = gmsh.model.getBoundary([(2, s)], oriented=True)
 
-        # Get points from these lines
+        # Get all points from these lines (not just the first 3): a face rebuilt by an
+        # OpenCASCADE boolean fragment/union can have two of its first few boundary
+        # vertices nearly coincident (a tiny sliver edge left over from the operation),
+        # and a plain 3-point cross product on a near-degenerate triple gives a
+        # near-random normal direction instead of the face's true orientation.
         points = []
         seen_points = set()
 
@@ -1122,26 +1126,46 @@ def create_model (excite_ports, settings):
                     coord = gmsh.model.getValue(0, ptag, [])
                     points.append(np.array(coord))
                     seen_points.add(ptag)
-                if len(points) == 3:
-                    break
-            if len(points) == 3:
-                break
 
-        # Compute surface normal using cross product
-        v1 = points[1] - points[0]
-        v2 = points[2] - points[0]
-        normal = np.cross(v1, v2)
-        normal = normal / np.linalg.norm(normal)
-        return normal
+        if len(points) < 3:
+            # Degenerate/sliver face left over from an OpenCASCADE boolean
+            # operation (e.g. a zero-width bridge from a self-touching
+            # "keyhole" polygon) - it has no meaningful orientation. Return
+            # NaN so the caller (is_vertical_surface) treats it as planar
+            # instead of crashing.
+            return np.array([np.nan, np.nan, np.nan])
+
+        # Newell's method: uses every boundary vertex, so a handful of
+        # near-collinear/near-duplicate ones (see above) get outvoted by the
+        # dominant planar signal from the rest of the polygon, instead of
+        # single-handedly determining the result the way 3 arbitrary points would.
+        normal = np.zeros(3)
+        n = len(points)
+        for i in range(n):
+            p1 = points[i]
+            p2 = points[(i + 1) % n]
+            normal[0] += (p1[1] - p2[1]) * (p1[2] + p2[2])
+            normal[1] += (p1[2] - p2[2]) * (p1[0] + p2[0])
+            normal[2] += (p1[0] - p2[0]) * (p1[1] + p2[1])
+
+        norm = np.linalg.norm(normal)
+        if norm == 0:
+            return np.array([np.nan, np.nan, np.nan])
+        return normal / norm
     
     def is_vertical_surface (s):
         # check if surface is not in xy plane
-        normal = get_surface_orientation(s)   
+        normal = get_surface_orientation(s)
         n = normal[2]
         if not np.isnan(n):
-            is_vertical = int(abs(n)) == 0
-        else:    
-            is_vertical = False    
+            # a horizontal (xy-plane) face has |n_z| close to 1; a vertical face has
+            # |n_z| close to 0. After OCC fragments/unions rebuild a face, its normal
+            # is rarely bit-exact, so compare against a threshold instead of using
+            # int(abs(n))==0, which was only ever False for a perfectly exact 1.0 and
+            # so misclassified almost every reconstructed horizontal face as vertical
+            is_vertical = abs(n) < 0.5
+        else:
+            is_vertical = False
         return is_vertical
     
    
@@ -1227,6 +1251,9 @@ def create_model (excite_ports, settings):
     # solver choice
     elmer = get_optional_setting(settings, 'elmer', False)
     elmer_thermal = get_optional_setting (settings, "elmer_thermal", False)
+    # thermal solve defaults to iterative (BiCGStabl); set settings['iterative']=False for
+    # a direct solver instead (UMFPACK - MUMPS is not available on Windows Elmer builds)
+    elmer_thermal_iterative = get_optional_setting (settings, "iterative", True)
     if elmer_thermal:
         elmer = True
         filled_metals = True # solid metal volumes for thermal
@@ -1582,8 +1609,16 @@ def create_model (excite_ports, settings):
 
     # dictionary of boundary tags (for refinement) per layer, also used for port. Key is layername or port name.
     boundary_line_tags_dict = {}
-    
-    geom_dimtags = [x for x in gmsh.model.occ.getEntities(dim=3)]     
+
+    # via lateral (vertical) surfaces get collected separately from metal_surface_dict
+    # while iterating below, then merged in afterwards - if a via's name were added to
+    # metal_surface_dict mid-loop, any *later* volume instance of that same via layer
+    # would hit the "if name in metal_surface_dict.keys()" branch below instead of the
+    # via-specific one, and get its full unfiltered surface set (including the
+    # horizontal mating faces this filtering is specifically meant to exclude)
+    via_surface_dict = {}
+
+    geom_dimtags = [x for x in gmsh.model.occ.getEntities(dim=3)]
     for dim, tag in geom_dimtags:
         name = gmsh.model.getEntityName(dim=3,tag=tag)
         if name in metal_surface_dict.keys():
@@ -1597,6 +1632,20 @@ def create_model (excite_ports, settings):
              
         elif name in metal_volume_dict.keys():
             metal_volume_dict[name].append(tag)
+
+            # vias are volume-only above, but also register their lateral (vertical)
+            # side surfaces as a physical group, for meshing/visualization. Top/bottom
+            # mating faces stay attributed to the metal layers the via connects to (they
+            # are already picked up by those layers' own surface registration above), so
+            # only keep the vertical faces here - including the mating faces would trip
+            # the "conductor layers touch" duplicate-surface check below as a false
+            # positive, since a via touching the metals above/below it is by design.
+            via_metal = metals_list.getbylayername(name)
+            if via_metal is not None and via_metal.is_via:
+                _, surfaceloops = gmsh.model.occ.getSurfaceLoops(tag)
+                vertical_faces = [t for loop in surfaceloops for t in loop if is_vertical_surface(t)]
+                if vertical_faces:
+                    via_surface_dict.setdefault(name, []).append([vertical_faces])
         elif name in dielectric_volume_dict.keys():
             dielectric_volume_dict[name].append(tag)
         elif name == "airbox":
@@ -1618,7 +1667,12 @@ def create_model (excite_ports, settings):
             if 'unknown' not in metal_volume_dict:
                 metal_volume_dict['unknown'] = []
             metal_volume_dict['unknown'].append(tag)
-            # exit(2)            
+            # exit(2)
+
+    # merge in via lateral surfaces now that the loop above is done (see comment
+    # where via_surface_dict is created for why this can't be merged in mid-loop)
+    for key, value in via_surface_dict.items():
+        metal_surface_dict[key] = value
 
 
     # create lists where we store dictionaries with material name, physical group tag and physical group name
@@ -1639,7 +1693,7 @@ def create_model (excite_ports, settings):
     # create physical group for metal surfaces
 
     already_assigned_tags = [] # list to check duplicates from two metals overlapping
-    
+
     for key in metal_surface_dict.keys():
         surfaces_list = metal_surface_dict[key]
         if len(surfaces_list)>0:
@@ -1659,12 +1713,12 @@ def create_model (excite_ports, settings):
                     else:
                         new_tags_planar.append(tag)     
 
-                    # we should not have this in list    
-                    if tag not in already_assigned_tags:    
-                        already_assigned_tags.append(tag)    
+                    # we should not have this in list
+                    if tag not in already_assigned_tags:
+                        already_assigned_tags.append(tag)
                     else:
                         print("ERROR in XML stackup definition:")
-                        print(f"   Polygon on conductor layer {key} touches another conductor layer (overlapping surface), this is invalid.")    
+                        print(f"   Polygon on conductor layer {key} touches another conductor layer (overlapping surface), this is invalid.")
                         print("   Make sure different 'conductor' layers never touch directly, use 'via' layer for connecting to metal layers!")
                         exit(101)
 
@@ -2416,11 +2470,12 @@ def create_model (excite_ports, settings):
             elmer_thermal_file = os.path.join(sim_path, 'case.sif')
             util_elmer.write_elmer_thermal_file (unit,
                                                     elmer_thermal_file,
-                                                    Elmer_materials, 
+                                                    Elmer_materials,
                                                     Elmer_bodies,
                                                     Elmer_boundaries,
                                                     Elmer_body_forces,
-                                                    Elmer_thermal_boundaryconditions)
+                                                    Elmer_thermal_boundaryconditions,
+                                                    iterative=elmer_thermal_iterative)
 
 
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -912,6 +912,16 @@ def add_ports (allpolygons, metals_list, simulation_ports, meshseed = 0):
 
 
 
+def _thermal_setup_error (message):
+    """Build a ValueError for a thermal-model XML/stackup configuration problem, with the
+    message wrapped in a "!" banner so the root cause stands out in the log even when
+    buried under gmsh "Info" lines and a multi-frame traceback (each printed as its own
+    line by setupThermal's stderr handler).
+    """
+    banner = "!" * 70
+    return ValueError(f"\n{banner}\nTHERMAL MODEL ERROR: {message}\n{banner}")
+
+
 def add_thermal_sources (allpolygons, metals_list, thermal_objects):
     """Add thermal_objects from special port layers to gmsh
 
@@ -946,8 +956,14 @@ def add_thermal_sources (allpolygons, metals_list, thermal_objects):
                         ymax = poly.ymax
                         
                         target_metal = metals_list.getbylayername(object.target_layername)
+                        if target_metal is None:
+                            raise _thermal_setup_error(
+                                f"Thermal source on GDS layer {object.source_layernum}: "
+                                f"target layer '{object.target_layername}' not found in stackup XML file. "
+                                "Check that the stackup XML matches this layout and defines this layer name."
+                            )
                         zmin = target_metal.zmin
-                        zmax = target_metal.zmax 
+                        zmax = target_metal.zmax
 
                         box_tag = gmsh.model.occ.addBox(xmin,ymin,zmin,xmax-xmin,ymax-ymin,zmax-zmin)
                         gmsh.model.setEntityName(dim=3,tag=box_tag, name=f'source_{object.source_layernum}')
@@ -991,6 +1007,12 @@ def add_thermal_boundaries (allpolygons, metals_list, thermal_objects):
 
                         #get target layer, first match in list
                         target_metal = metals_list.getbylayername (object.target_layername)
+                        if target_metal is None:
+                            raise _thermal_setup_error(
+                                f"Constant-temperature boundary on GDS layer {object.source_layernum}: "
+                                f"target layer '{object.target_layername}' not found in stackup XML file. "
+                                "Check that the stackup XML matches this layout and defines this layer name."
+                            )
                         for surfacetag_bot in create_surfaces_from_polygon (poly, target_metal.zmin, 0):
                             gmsh.model.setEntityName(dim=2,tag=surfacetag_bot, name=f'constanttemp_{object.source_layernum}')
                             surface_tags.append(surfacetag_bot)
@@ -2217,7 +2239,13 @@ def create_model (excite_ports, settings):
                     if elmer_thermal:
                         Elmer_material['density']=material.density
                         if material.thermaltablename == "":
-                            # single value 
+                            # single value
+                            if material.thermalcond == 0:
+                                raise _thermal_setup_error(
+                                    f'Material "{material.name}" has no ThermalConductivity defined in the stackup '
+                                    'XML file (defaults to 0 W/m/K). Thermal simulation results would be meaningless '
+                                    '-- add a ThermalConductivity attribute for this material in the stackup XML file.'
+                                )
                             Elmer_material['thermalcond']=material.thermalcond
                         else:
                             # table

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -223,7 +223,7 @@ class constanttemp:
     Returns:
         string: string representation 
     """
-    mystr = f"constant temperature boundary T= {self.temperature} K  GDS source layer = {self.source_layernum}  target layer = {self.target_layername}"
+    mystr = f"constant temperature boundary T= {self.temp} K  GDS source layer = {self.source_layernum}  target layer = {self.target_layername}"
     return mystr
 
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1808,6 +1808,21 @@ def create_model (excite_ports, settings):
 
     # refinement value controls adaptive mesh refinement
     # always write this control block, even when 0 iterations specified, because user can then edit json himself
+    #
+    # Investigated (not implemented): an HFSS-style two-stage AMR, where a first Palace run
+    # meshes cheaply at only 1-2 frequencies (SaveAdaptMesh: true) and a second run loads that
+    # adapted mesh (config["Model"]["Mesh"] pointed at the .mesh file, MaxIts: 0) for one
+    # full-band sweep on the fixed mesh, instead of paying for the full sweep on every AMR pass.
+    # The mesh hand-off mechanism works (Palace accepts SaveAdaptMesh's MFEM-native .mesh file
+    # directly as Model.Mesh input, and reproduces matching S-parameters), but on a real test
+    # case (2-port inductor, ~250k unknowns after 2 AMR passes) the two-stage total was SLOWER
+    # than the existing single-stage flow (152s vs 124s) - because AdaptiveTol's PROM-based
+    # adaptive frequency sweep already keeps "full sweep every AMR pass" cheap (only ~15-20
+    # full-order solves get interpolated across the whole band, not one solve per sample), and a
+    # fresh second Palace invocation pays its own fixed overhead (mesh preprocessing, operator
+    # construction, preconditioner setup, a final error-estimate pass) that ate up the savings
+    # from the cheaper AMR stage. Not worth the added complexity unless a future, much larger
+    # model shows the fixed per-invocation overhead becoming a small fraction of total time.
     Refinement = {
         "UniformLevels": 0,
         "Tol": 1e-2,

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1153,6 +1153,7 @@ def create_model (excite_ports, settings):
 
     fstart = get_optional_setting (settings, 'fstart', None)
     fstop  = get_optional_setting (settings, 'fstop', None)
+    fstep  = None
     if (fstart is not None) and (fstop is not None):
         fstep  = get_optional_setting (settings, "fstep", (fstop-fstart)/100)
 
@@ -1279,11 +1280,13 @@ def create_model (excite_ports, settings):
     print('Starting to create mesh file and config file')
 
     fmax = 0
-    if fstop is not None: 
+    if fstop is not None:
         fmax = max(fmax, fstop)
-    if len(f_discrete_list) > 0: 
-        discrete_max = max(f_discrete_list) 
+    if len(f_discrete_list) > 0:
+        discrete_max = max(f_discrete_list)
         fmax = max(fmax, discrete_max)
+    if len(f_dump_list) > 0:
+        fmax = max(fmax, max(f_dump_list))
 
     wavelength_air = 3e8/fmax / unit
     # max_cellsize = min((wavelength_air)/(math.sqrt(materials_list.eps_max)*cells_per_wavelength), meshsize_max)
@@ -2390,15 +2393,16 @@ def create_model (excite_ports, settings):
             # write *.sif file for Elmer
             elmer_physics_file = os.path.join(sim_path, 'physics.sif')
             util_elmer.write_elmer_physics_file (unit,
-                                                    elmer_physics_file, 
-                                                    num_frequencies, 
-                                                    Elmer_materials, 
+                                                    elmer_physics_file,
+                                                    num_frequencies,
+                                                    Elmer_materials,
                                                     Elmer_bodies,
                                                     Elmer_boundaries,
                                                     Elmer_ports,
                                                     PEC_boundaries,
                                                     PML_boundaries,
-                                                    PMC_boundaries)
+                                                    PMC_boundaries,
+                                                    f_dump_list=f_dump_list)
 
 
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -2327,7 +2327,8 @@ def create_model (excite_ports, settings):
             for item in physical_groups_ports:
                 layername, portname, grouptag = item.values()
 
-                portnum = int(portname.replace('P',''))           
+                portnum = int(portname.replace('P',''))
+                port = simulation_ports.get_port_by_number(portnum)
                 Elmer_port_boundary = {}
                 Elmer_port_boundary['name'] = portname
                 Elmer_port_boundary['portnum'] = portnum

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -18,7 +18,7 @@
 
 # -*- coding: utf-8 -*-
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 import os
 import sys

--- a/workflow/gds2palace/util_utilities.py
+++ b/workflow/gds2palace/util_utilities.py
@@ -111,19 +111,31 @@ def create_elmer_run_script (destination_path, settings):
 
     ELMER_MPI_THREADS = util_elmer.get_ELMER_MPI_THREADS(settings)
 
-    if ELMER_MPI_THREADS==1:
-        txt = '#!/bin/bash\n'
-        txt = txt + 'ElmerSolver\n'
+    if platform.system() == "Windows":
+        # No mpirun on Windows - MS-MPI ships mpiexec instead (different flag: -n, not -np).
+        # Plain .bat content, no "#!/bin/bash" shebang line (that's meaningless to cmd.exe
+        # and would print a bogus "not recognized" line, though otherwise harmless there).
+        if ELMER_MPI_THREADS == 1:
+            txt = 'ElmerSolver\n'
+        else:
+            txt = f'mpiexec -n {ELMER_MPI_THREADS} ElmerSolver case.sif\n'
         txt = txt + 'combine_snp\n'
+        cmd_filename = os.path.join(destination_path, 'run_elmer.bat')
+        with open(cmd_filename, "w", newline='\r\n') as f:  # write with Windows EOL
+            f.write(txt)
     else:
-        txt = '#!/bin/bash\n'
-        txt = txt + f'mpirun -np {ELMER_MPI_THREADS} ElmerSolver case.sif\n'
-        txt = txt + 'combine_snp\n'
+        if ELMER_MPI_THREADS==1:
+            txt = '#!/bin/bash\n'
+            txt = txt + 'ElmerSolver\n'
+            txt = txt + 'combine_snp\n'
+        else:
+            txt = '#!/bin/bash\n'
+            txt = txt + f'mpirun -np {ELMER_MPI_THREADS} ElmerSolver case.sif\n'
+            txt = txt + 'combine_snp\n'
 
-    cmd_filename = os.path.join(destination_path, 'run_elmer')
-    with open(cmd_filename, "w", newline='\n') as f:  # write with UNIX EOL
-        f.write(txt)
-    f.close()       
+        cmd_filename = os.path.join(destination_path, 'run_elmer')
+        with open(cmd_filename, "w", newline='\n') as f:  # write with UNIX EOL
+            f.write(txt)
 
 
 def check_module_version(module_name, expected_version):


### PR DESCRIPTION
## Summary
- AMR: fix port-impedance lookup for adaptive mesh refinement iterations, add Max Delta-S convergence metric, drop unused/less-useful error indicators from results parsing and summary output.
- Elmer thermal: add a direct (UMFPACK) linear solver option alongside the existing iterative BiCGStabl solver, loosen default convergence tolerance and raise the iteration cap.
- Fix two related mesh-generation bugs on complex OpenCASCADE boolean-fragmented geometry: `is_vertical_surface()`'s inverted-ish threshold check, and `get_surface_orientation()`'s fragile 3-point normal (now Newell's method over all boundary vertices).
- Vias now get surface physical groups for their lateral (vertical) side faces too, not just a volume - useful for Elmer thermal mesh visualization in Paraview.
- Fix Elmer EM silently re-solving the same frequency twice when it appeared in both the sweep and fpoint/fdump - `write_elmer_frequencies()` now dedupes the combined list.
- Fix a stray-variable bug in Elmer port Z0/direction reading, and `constanttemp.__str__` referencing the wrong attribute.
- Add clearer errors for thermal model XML/stackup misconfiguration.
- Fix fdump-only crashes and enable/fix Elmer EM field dumps on Windows.
- Add `doc/ARCHITECTURE.md` (AI-agent reference for the codebase).
- Declare `numpy` as an actual package dependency (was imported directly but undeclared, working only via gdspy's own transitive dependency), and document ParaView/MPI as external tools required for parts of the workflow.
- Reorganize `scripts/README.md` into topic sections.
- Version bumped to 0.4.3 (published to PyPI).

## Test plan
- Verified mesh generation, direct/iterative Elmer thermal solves, and via surface physical groups end-to-end on the interposer thermal test case (full ElmerSolver run converges).
- Verified the Elmer EM frequency dedup fix directly (exact + near-duplicate collapse to one line) and end-to-end via `create_elmer()` (no extra solved frequencies from an overlapping fdump value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)