### PR TITLE
Elmer thermal solver options, via/surface mesh fixes, frequency dedup, dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ In addition to Palace that is required for simulation of the output files, these
 - matplotlib (for the inductor synthesis example scripts)
 - scikit-rf (for the script that converts Palace output to Touchstone SnP format)
 
+Two external tools are needed for parts of the workflow, but are not Python modules and must be installed separately:
+
+- [ParaView](https://www.paraview.org/) — to view field-dump output (Palace/Elmer EM) and Elmer thermal result files.
+- An MPI implementation — only needed for multi-process Elmer runs (`settings['ELMER_MPI_THREADS']`). Use OpenMPI or MPICH on Linux/macOS; on Windows, install [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi).
+
 Documentation assumes that you have created a Python venv named "palace" in ~/venv/palace and installed the modules there.
 
 ## Installing Palace

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -9,6 +9,8 @@ Fixed two related bugs in mesh generation that caused `IndexError`/`Could not cr
 
 Vias now also get surface physical groups for their lateral (vertical) side faces, not just a volume — useful for Elmer thermal mesh visualization in Paraview. Top/bottom mating faces stay attributed to the metal layers the via connects to, to avoid a false "conductor layers touch" error.
 
+Fixed Elmer EM simulations silently re-solving the same frequency twice: `write_elmer_frequencies()` combined the swept range with `fpoint`/`fdump` values without checking for overlap, so a frequency that happened to appear in both the sweep and `fpoint`/`fdump` landed on two separate lines of `frequencies.dat` — and Elmer's "Scanning" simulation solves every line as an independent full simulation task, addressed by index, not by value. The combined list is now de-duplicated before being written.
+
 ## 05-September-2026
 Elmer EM (S-parameter) simulations can now actually write field-dump data when `fdump` frequencies are set — this was silently doing nothing before. Fixed a crash when `fdump` was used without also specifying a frequency sweep (`fstart`/`fstop`), for both Palace and Elmer output. Fixed the generated Elmer run script on Windows, which used Linux-only `mpirun`/bash syntax and never actually worked there.
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,13 @@
 
 This is an (incomplete) list of changes and new features.
 
+## 06-September-2026
+Elmer thermal simulations can now use a direct linear solver (UMFPACK) instead of the iterative BiCGStabl solver, via `settings['iterative']=False` — useful when the iterative solver fails to converge on a large conductivity contrast between materials. Loosened the default iterative solver's convergence tolerance and raised its iteration cap, since the previous defaults could fail to converge on some models.
+
+Fixed two related bugs in mesh generation that caused `IndexError`/`Could not create line` crashes on complex geometry involving OpenCASCADE boolean fragments: `is_vertical_surface()` used a threshold check (`int(abs(n))==0`) that misclassified almost every reconstructed horizontal face as vertical, and `get_surface_orientation()` computed a face's normal from only its first 3 boundary vertices, which could be near-collinear after a boolean fragment/union rebuilt the face. Both are now more robust (proper threshold, and Newell's method over all boundary vertices).
+
+Vias now also get surface physical groups for their lateral (vertical) side faces, not just a volume — useful for Elmer thermal mesh visualization in Paraview. Top/bottom mating faces stay attributed to the metal layers the via connects to, to avoid a false "conductor layers touch" error.
+
 ## 05-September-2026
 Elmer EM (S-parameter) simulations can now actually write field-dump data when `fdump` frequencies are set — this was silently doing nothing before. Fixed a crash when `fdump` was used without also specifying a frequency sweep (`fstart`/`fstop`), for both Palace and Elmer output. Fixed the generated Elmer run script on Windows, which used Linux-only `mpirun`/bash syntax and never actually worked there.
 

--- a/doc/userguide_md_format/gds2palace_workflow_userguide.md
+++ b/doc/userguide_md_format/gds2palace_workflow_userguide.md
@@ -11,6 +11,7 @@ Document version: 2026-08-17
 [Required software and Python modules](#required-software-and-python-modules)  
 &ensp;[Recommended installation of gds2palace as Python module](#recommended-installation-of-gds2palace-as-python-module)  
 &ensp;[Alternative, no longer recommended: local gds2palace directory](#alternative-no-longer-recommended-local-gds2palace-directory)  
+&ensp;[External tools (not Python modules)](#external-tools-not-python-modules)  
 [Installing AWS Palace](#installing-aws-palace)  
 &ensp;[Installing the Palace solver using Apptainer](#installing-the-palace-solver-using-apptainer)  
 &ensp;[Installing the Palace solver using spack package manager](#installing-the-palace-solver-using-spack-package-manager)  
@@ -135,6 +136,13 @@ This virtual environment with installed dependencies can be used to run gds2pala
 ```
 source ~/venv/palace/bin/activate
 ```
+
+### External tools (not Python modules)
+
+Two more tools are needed for parts of the workflow, but are not installed via pip:
+
+- [ParaView](https://www.paraview.org/) — to view field-dump output (Palace/Elmer EM) and Elmer thermal result files.
+- An MPI implementation — only needed for multi-process Elmer runs (`settings['ELMER_MPI_THREADS']`, see chapter "Installing Elmer FEM"). Use OpenMPI or MPICH on Linux/macOS; on Windows, install [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi).
 
 ## Installing AWS Palace 
 
@@ -786,6 +794,8 @@ Elmer FEM is not distributed with gds2palace and must be installed separately, s
 
 - **Windows:** set the environment variable `ELMER_HOME` to your Elmer install directory. gds2palace looks for `%ELMER_HOME%\bin\ElmerGrid.exe`.
 - **Linux/macOS:** make sure `ElmerGrid` and `ElmerSolver` are available on your `PATH`.
+
+If you use `settings['ELMER_MPI_THREADS']` to run Elmer across multiple processes, you also need an MPI implementation installed (see "External tools (not Python modules)" above) — on Windows this is Microsoft MPI, providing the `mpiexec`/`mpirun` launcher the generated `run_elmer` script uses.
 
 ### From a Palace model to an Elmer model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.9"
 dependencies = [
     "gdspy>1.6.0",
     "gmsh",
+    "numpy",
 ]
 
 [project.urls]

--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.4.2"   # version of gds2palace
+__version__ = "0.4.3"   # version of gds2palace
 

--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.4.1"   # version of gds2palace
+__version__ = "0.4.2"   # version of gds2palace
 

--- a/workflow/gds2palace/util_elmer.py
+++ b/workflow/gds2palace/util_elmer.py
@@ -392,15 +392,28 @@ def write_case_and_solver_files (targetdir, order, iterative, ELMER_MPI_THREADS=
 
 def write_elmer_thermal_file (unit,
                                 elmer_thermal_file,
-                                Elmer_materials, 
+                                Elmer_materials,
                                 Elmer_bodies,
                                 Elmer_boundaries,
                                 Elmer_body_forces,
-                                Elmer_thermal_boundaryconditions):
-    
+                                Elmer_thermal_boundaryconditions,
+                                iterative=True):
+
     with open(elmer_thermal_file, "w") as f:
 
         vtu_file = '../thermal_results.vtu'
+
+        if iterative:
+            linear_system_block = '''Linear System Solver = Iterative
+Linear System Iterative Method = BiCGStabl
+Linear System Max Iterations = 100000
+Linear System Convergence Tolerance = 1.0e-7
+Linear System Preconditioning = ILU1'''
+        else:
+            # MUMPS is not available in the Windows Elmer build - UMFPACK ships
+            # with Elmer on all platforms and needs no extra solver-specific options
+            linear_system_block = '''Linear System Solver = Direct
+Linear System Direct Method = umfpack'''
 
         header1=f'''
 Check Keywords "warn"
@@ -430,11 +443,7 @@ Solver 1
 Equation = Heat Equation
 Procedure = "HeatSolve" "HeatSolver"
 Variable = Temperature
-Linear System Solver = Iterative
-Linear System Iterative Method = BiCGStabl
-Linear System Max Iterations = 2500
-Linear System Convergence Tolerance = 1.0e-10
-Linear System Preconditioning = ILU1
+{linear_system_block}
 Steady State Convergence Tolerance = 1.0e-5
 End        
 

--- a/workflow/gds2palace/util_elmer.py
+++ b/workflow/gds2palace/util_elmer.py
@@ -52,6 +52,24 @@ def write_elmer_frequencies (elmer_freq_file,
 
             # sort and write to file
             frequency_list.sort()
+
+            # De-duplicate: Elmer's "Scanning" simulation solves one full pass per
+            # line of frequencies.dat, addressed by index - a duplicate value on two
+            # lines (whether bit-identical, or merely rounding to the same text
+            # below) means Elmer silently re-solves the same physical frequency
+            # twice. Coincidental overlap between the sweep, fpoint, and fdump (or
+            # float drift from repeated "f = f + fstep" additions landing next to a
+            # user-specified value) is common, so dedupe on the same 3-significant-
+            # digit text written below rather than exact float equality.
+            deduped = []
+            seen = set()
+            for freq in frequency_list:
+                key = f"{freq:.3e}"
+                if key not in seen:
+                    seen.add(key)
+                    deduped.append(freq)
+            frequency_list = deduped
+
             for n, freq in enumerate(frequency_list):
                 freqfile.write(f"{n+1}  {freq:.3e}\n")
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1111,7 +1111,11 @@ def create_model (excite_ports, settings):
         # Get the boundary of the surface
         boundary_lines  = gmsh.model.getBoundary([(2, s)], oriented=True)
 
-        # Get points from these lines
+        # Get all points from these lines (not just the first 3): a face rebuilt by an
+        # OpenCASCADE boolean fragment/union can have two of its first few boundary
+        # vertices nearly coincident (a tiny sliver edge left over from the operation),
+        # and a plain 3-point cross product on a near-degenerate triple gives a
+        # near-random normal direction instead of the face's true orientation.
         points = []
         seen_points = set()
 
@@ -1122,26 +1126,46 @@ def create_model (excite_ports, settings):
                     coord = gmsh.model.getValue(0, ptag, [])
                     points.append(np.array(coord))
                     seen_points.add(ptag)
-                if len(points) == 3:
-                    break
-            if len(points) == 3:
-                break
 
-        # Compute surface normal using cross product
-        v1 = points[1] - points[0]
-        v2 = points[2] - points[0]
-        normal = np.cross(v1, v2)
-        normal = normal / np.linalg.norm(normal)
-        return normal
+        if len(points) < 3:
+            # Degenerate/sliver face left over from an OpenCASCADE boolean
+            # operation (e.g. a zero-width bridge from a self-touching
+            # "keyhole" polygon) - it has no meaningful orientation. Return
+            # NaN so the caller (is_vertical_surface) treats it as planar
+            # instead of crashing.
+            return np.array([np.nan, np.nan, np.nan])
+
+        # Newell's method: uses every boundary vertex, so a handful of
+        # near-collinear/near-duplicate ones (see above) get outvoted by the
+        # dominant planar signal from the rest of the polygon, instead of
+        # single-handedly determining the result the way 3 arbitrary points would.
+        normal = np.zeros(3)
+        n = len(points)
+        for i in range(n):
+            p1 = points[i]
+            p2 = points[(i + 1) % n]
+            normal[0] += (p1[1] - p2[1]) * (p1[2] + p2[2])
+            normal[1] += (p1[2] - p2[2]) * (p1[0] + p2[0])
+            normal[2] += (p1[0] - p2[0]) * (p1[1] + p2[1])
+
+        norm = np.linalg.norm(normal)
+        if norm == 0:
+            return np.array([np.nan, np.nan, np.nan])
+        return normal / norm
     
     def is_vertical_surface (s):
         # check if surface is not in xy plane
-        normal = get_surface_orientation(s)   
+        normal = get_surface_orientation(s)
         n = normal[2]
         if not np.isnan(n):
-            is_vertical = int(abs(n)) == 0
-        else:    
-            is_vertical = False    
+            # a horizontal (xy-plane) face has |n_z| close to 1; a vertical face has
+            # |n_z| close to 0. After OCC fragments/unions rebuild a face, its normal
+            # is rarely bit-exact, so compare against a threshold instead of using
+            # int(abs(n))==0, which was only ever False for a perfectly exact 1.0 and
+            # so misclassified almost every reconstructed horizontal face as vertical
+            is_vertical = abs(n) < 0.5
+        else:
+            is_vertical = False
         return is_vertical
     
    
@@ -1227,6 +1251,9 @@ def create_model (excite_ports, settings):
     # solver choice
     elmer = get_optional_setting(settings, 'elmer', False)
     elmer_thermal = get_optional_setting (settings, "elmer_thermal", False)
+    # thermal solve defaults to iterative (BiCGStabl); set settings['iterative']=False for
+    # a direct solver instead (UMFPACK - MUMPS is not available on Windows Elmer builds)
+    elmer_thermal_iterative = get_optional_setting (settings, "iterative", True)
     if elmer_thermal:
         elmer = True
         filled_metals = True # solid metal volumes for thermal
@@ -1582,8 +1609,16 @@ def create_model (excite_ports, settings):
 
     # dictionary of boundary tags (for refinement) per layer, also used for port. Key is layername or port name.
     boundary_line_tags_dict = {}
-    
-    geom_dimtags = [x for x in gmsh.model.occ.getEntities(dim=3)]     
+
+    # via lateral (vertical) surfaces get collected separately from metal_surface_dict
+    # while iterating below, then merged in afterwards - if a via's name were added to
+    # metal_surface_dict mid-loop, any *later* volume instance of that same via layer
+    # would hit the "if name in metal_surface_dict.keys()" branch below instead of the
+    # via-specific one, and get its full unfiltered surface set (including the
+    # horizontal mating faces this filtering is specifically meant to exclude)
+    via_surface_dict = {}
+
+    geom_dimtags = [x for x in gmsh.model.occ.getEntities(dim=3)]
     for dim, tag in geom_dimtags:
         name = gmsh.model.getEntityName(dim=3,tag=tag)
         if name in metal_surface_dict.keys():
@@ -1597,6 +1632,20 @@ def create_model (excite_ports, settings):
              
         elif name in metal_volume_dict.keys():
             metal_volume_dict[name].append(tag)
+
+            # vias are volume-only above, but also register their lateral (vertical)
+            # side surfaces as a physical group, for meshing/visualization. Top/bottom
+            # mating faces stay attributed to the metal layers the via connects to (they
+            # are already picked up by those layers' own surface registration above), so
+            # only keep the vertical faces here - including the mating faces would trip
+            # the "conductor layers touch" duplicate-surface check below as a false
+            # positive, since a via touching the metals above/below it is by design.
+            via_metal = metals_list.getbylayername(name)
+            if via_metal is not None and via_metal.is_via:
+                _, surfaceloops = gmsh.model.occ.getSurfaceLoops(tag)
+                vertical_faces = [t for loop in surfaceloops for t in loop if is_vertical_surface(t)]
+                if vertical_faces:
+                    via_surface_dict.setdefault(name, []).append([vertical_faces])
         elif name in dielectric_volume_dict.keys():
             dielectric_volume_dict[name].append(tag)
         elif name == "airbox":
@@ -1618,7 +1667,12 @@ def create_model (excite_ports, settings):
             if 'unknown' not in metal_volume_dict:
                 metal_volume_dict['unknown'] = []
             metal_volume_dict['unknown'].append(tag)
-            # exit(2)            
+            # exit(2)
+
+    # merge in via lateral surfaces now that the loop above is done (see comment
+    # where via_surface_dict is created for why this can't be merged in mid-loop)
+    for key, value in via_surface_dict.items():
+        metal_surface_dict[key] = value
 
 
     # create lists where we store dictionaries with material name, physical group tag and physical group name
@@ -1639,7 +1693,7 @@ def create_model (excite_ports, settings):
     # create physical group for metal surfaces
 
     already_assigned_tags = [] # list to check duplicates from two metals overlapping
-    
+
     for key in metal_surface_dict.keys():
         surfaces_list = metal_surface_dict[key]
         if len(surfaces_list)>0:
@@ -1659,12 +1713,12 @@ def create_model (excite_ports, settings):
                     else:
                         new_tags_planar.append(tag)     
 
-                    # we should not have this in list    
-                    if tag not in already_assigned_tags:    
-                        already_assigned_tags.append(tag)    
+                    # we should not have this in list
+                    if tag not in already_assigned_tags:
+                        already_assigned_tags.append(tag)
                     else:
                         print("ERROR in XML stackup definition:")
-                        print(f"   Polygon on conductor layer {key} touches another conductor layer (overlapping surface), this is invalid.")    
+                        print(f"   Polygon on conductor layer {key} touches another conductor layer (overlapping surface), this is invalid.")
                         print("   Make sure different 'conductor' layers never touch directly, use 'via' layer for connecting to metal layers!")
                         exit(101)
 
@@ -2416,11 +2470,12 @@ def create_model (excite_ports, settings):
             elmer_thermal_file = os.path.join(sim_path, 'case.sif')
             util_elmer.write_elmer_thermal_file (unit,
                                                     elmer_thermal_file,
-                                                    Elmer_materials, 
+                                                    Elmer_materials,
                                                     Elmer_bodies,
                                                     Elmer_boundaries,
                                                     Elmer_body_forces,
-                                                    Elmer_thermal_boundaryconditions)
+                                                    Elmer_thermal_boundaryconditions,
+                                                    iterative=elmer_thermal_iterative)
 
 
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -18,7 +18,7 @@
 
 # -*- coding: utf-8 -*-
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 import os
 import sys


### PR DESCRIPTION
## Summary
- Elmer thermal: add a direct (UMFPACK) linear solver option alongside the existing iterative BiCGStabl solver, loosen default convergence tolerance and raise the iteration cap.
- Fix two related mesh-generation bugs on complex OpenCASCADE boolean-fragmented geometry: `is_vertical_surface()`'s inverted-ish threshold check, and `get_surface_orientation()`'s fragile 3-point normal (now Newell's method over all boundary vertices).
- Vias now get surface physical groups for their lateral (vertical) side faces too, not just a volume - useful for Elmer thermal mesh visualization in Paraview.
- Fix Elmer EM silently re-solving the same frequency twice when it appeared in both the sweep and fpoint/fdump - `write_elmer_frequencies()` now dedupes the combined list.
- Declare `numpy` as an actual package dependency (was imported directly but undeclared, working only via gdspy's own transitive dependency), and document ParaView/MPI as external tools required for parts of the workflow.
- Version bumped to 0.4.3 (published to PyPI).

## Test plan
- Verified mesh generation, direct/iterative Elmer thermal solves, and via surface physical groups end-to-end on the interposer thermal test case (full ElmerSolver run converges).
- Verified the Elmer EM frequency dedup fix directly (exact + near-duplicate collapse to one line) and end-to-end via `create_elmer()` (no extra solved frequencies from an overlapping fdump value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)