### PR TITLE
Reserved PEC/AIR stackup materials, configurable AMR settings

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,9 @@
 
 This is an (incomplete) list of changes and new features.
 
+## 12-September-2026
+Added two reserved stackup materials that need no `<Materials>` entry: `PEC` (ideal conductor, on conductor/via/sheet Layers) and `AIR` (built-in default dielectric, overridable).
+
 ## 09-September-2026
 Added `more_examples/mesh_convergence/`: five worked mesh convergence studies (how fine to mesh, whether adaptive mesh refinement helps) on real IHP SG13G2 structures — see the [overview](../more_examples/mesh_convergence/README.md) for what we found. Examples: [spiral inductor](../more_examples/mesh_convergence/mesh_convergence_inductor/mesh_convergence_report.md), [transformer](../more_examples/mesh_convergence/mesh_convergence_transformer/mesh_convergence_report.md), [D-band balun](../more_examples/mesh_convergence/mesh_convergence_D-band_balun/mesh_convergence_report.md), [2:1 edge-coupled balun](../more_examples/mesh_convergence/mesh_convergence_balun2x1/mesh_convergence_report.md), [MIM-loaded balun](../more_examples/mesh_convergence/mesh_convergence_balun_mim/mesh_convergence_report.md).
 

--- a/doc/XML_stackup_format/XML_stackup_format.md
+++ b/doc/XML_stackup_format/XML_stackup_format.md
@@ -65,6 +65,12 @@ elements later in the file.
 | `ThermalConductivityTable`   | no       | —       | Name of a `<Table>` (see [Tables](#tables-thermal-conductivity) below) to use instead of a constant value, for temperature-dependent conductivity. |
 | `Color`                     | no       | —       | Hex RGB color (no `#`), used for 3D preview / GUI display. |
 
+> **Built-in default `"AIR"`:** if the file has no `<Material Name="AIR">` entry, one is added
+> automatically (`Type="Dielectric" Permittivity="1.0" DielectricLossTangent="0.0"
+> Conductivity="0" Color="d0d0d0"` — the same values used across the example stackups in this
+> repo), so `Material="AIR"` just works on a `<Dielectric>`/`<Layer>` without declaring it
+> explicitly. Defining your own `<Material Name="AIR">` overrides this default.
+
 ```xml
 <Materials>
   <Material Name="Metal1" Type="Conductor" Permittivity="1" DielectricLossTangent="0"
@@ -170,7 +176,7 @@ that is itself modeled with negative z).
 |-----------|----------|---------|--------------|
 | `Name`    | yes      | —       | Layer name, used for lookups (`getbylayername`) and in port definitions (`from_layername`/`to_layername` etc. elsewhere in the pipeline). Must be unique across `<Layers>`, and must not collide with a `<Dielectric>` name (see `Reference` below). |
 | `Type`    | yes      | —       | `conductor`, `via`, `dielectric`, or `sheet` (see below). |
-| `Material`| yes      | —       | References a `<Material>` by name. |
+| `Material`| yes      | —       | References a `<Material>` by name, or the reserved keyword `"PEC"` (see below). |
 | `Zmin`    | yes      | —       | Bottom z-position — absolute, or an offset from `Reference`'s edge if `Reference` is set (see below). |
 | `Zmax`    | yes      | —       | Top z-position, same absolute-vs-offset rule as `Zmin`. Equal to `Zmin` forces `Type` to `sheet` regardless of the stated `Type`. |
 | `Layer`   | yes      | —       | GDSII layer number. Also used as the target layer number for a [derived layer](#derivedlayers-boolean-operations-on-layers), in which case its geometry does not need to exist directly in the GDSII file. |
@@ -185,6 +191,16 @@ Layer `Type` meanings:
   stack in `<Dielectrics>`.
 - **`sheet`** — zero-thickness layer (`Zmin == Zmax`), typically paired with a `Resistor`
   material for sheet-resistance elements.
+
+> **Reserved keyword `Material="PEC"`:** valid on a `conductor`, `via`, or `sheet` layer with no
+> matching `<Material>` entry at all — it bypasses the `<Materials>` list entirely and is
+> emitted as an ideal conductor (ideal Palace `Boundaries.PEC` / Elmer zero-tangential-E
+> boundary for `conductor`/`sheet`; for `via`, both are FEM solvers with no ideal-conductor
+> *volume*, so it's approximated there as a fixed, very high conductivity domain instead).
+> Use this instead of an ad hoc zero-Ohm/near-infinite-conductivity material - a `Resistor`
+> material with `Rs="0"` is rejected by Palace (all of `Rs`/`Ls`/`Cs` zero is invalid). Not
+> valid together with Elmer thermal output (`elmer_thermal`/`setupThermal`), which has no
+> electromagnetic concept of PEC.
 
 ```xml
 <Layers>

--- a/workflow/gds2palace/__init__.py
+++ b/workflow/gds2palace/__init__.py
@@ -22,5 +22,5 @@ from . import util_gds_reader as gds_reader
 from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 
-__version__ = "0.4.4"   # version of gds2palace
+__version__ = "0.5.0"   # version of gds2palace
 

--- a/workflow/gds2palace/util_elmer.py
+++ b/workflow/gds2palace/util_elmer.py
@@ -85,6 +85,7 @@ def write_elmer_physics_file (unit,
                               Elmer_materials,
                               Elmer_bodies,
                               Elmer_boundaries,
+                              Elmer_boundaries_PEC,
                               Elmer_ports,
                               PEC_boundaries,
                               PML_boundaries,
@@ -169,6 +170,19 @@ def write_elmer_physics_file (unit,
                 item = item + f'   Port Type = String "rectangular"\n'
                 item = item + f'   Port Impedance = Real {portZ0}\n'
                 item = item + f'   Port Direction = Integer {direction}\n'
+                item = item + "End\n"
+                f.write(item + '\n')
+
+            # write per-layer PEC boundaries section: a conductor/via/sheet layer that used the
+            # reserved "PEC" material gets its own ideal-conductor boundary condition here, using
+            # the exact same literal zero-tangential-E construct as the outer airbox PEC boundary
+            # below - just scoped to this layer's own physical group instead of the shared one
+            for name in Elmer_boundaries_PEC:
+                n = n+1 # continue number range started in metal boundaries
+                item = f'Boundary Condition {n+1}\n'
+                item = item + f'   Name = "{name}"\n'
+                item = item +  '   E re {e} = Real 0\n'
+                item = item +  '   E im {e} = Real 0\n'
                 item = item + "End\n"
                 f.write(item + '\n')
 

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -18,7 +18,7 @@
 
 # -*- coding: utf-8 -*-
 
-__version__ = "1.5.1"
+__version__ = "1.6.0"
 
 import os
 import sys
@@ -27,7 +27,26 @@ import math
 import numpy as np
 import json
 
-from . import util_elmer 
+from . import util_elmer
+from .util_stackup_reader import PEC_MATERIAL_NAME
+
+# Neither Palace nor Elmer (both FEM continuum solvers) can represent a literal ideal-conductor
+# 3D volume - a PEC via is instead approximated with this fixed, very high but finite
+# conductivity domain material. Matches the ad hoc "LOWLOSS" workaround already used in
+# test_data/zeromargin/SG13G2_PEC_at_M1.xml. (openEMS, being FDTD, has no such limitation and
+# uses a literal ideal-conductor volume for a PEC via instead - see gds2openEMS.)
+PEC_VIA_EQUIVALENT_CONDUCTIVITY = 1e10
+
+
+def _is_pec_material (materialname):
+  """True if materialname is the reserved PEC_MATERIAL_NAME (case-insensitive), i.e. a
+     Layer Material="..." that should bypass normal materials_list lookup entirely.
+  Args:
+      materialname (string): raw metal_layer.material value
+  Returns:
+      bool
+  """
+  return materialname is not None and materialname.strip().upper() == PEC_MATERIAL_NAME.upper()
 
 
 class simulation_port:
@@ -1993,9 +2012,35 @@ def create_model (excite_ports, settings):
     Palace_materials = []
 
     for item in physical_groups_3D:
-        # items can be from via layer or from dielectric stackup
+        # items can be from via layer, filled/solid metal volume, or dielectric stackup
 
         layername, groupname, grouptag = item.values()
+        metal = metals_list.getbylayername(layername)
+
+        if metal is not None and _is_pec_material(metal.material):
+            if elmer_thermal:
+                raise _thermal_setup_error(
+                    f'Layer "{metal.name}" uses the reserved "PEC" material, which is an '
+                    'electromagnetic-only construct, not valid for thermal simulation -- assign '
+                    'a real Conductor material with ThermalConductivity for this layer instead.'
+                )
+            # PEC via or filled/solid metal: Palace has no ideal-conductor volume, approximate
+            # with a fixed very high but finite conductivity domain instead
+            print(f'Layer "{metal.name}" uses the reserved "PEC" material - approximated as a '
+                  f'{PEC_VIA_EQUIVALENT_CONDUCTIVITY:.0e} S/m conductivity domain, since Palace '
+                  f'has no ideal-conductor volume.')
+            Palace_material = {}
+            Palace_material['Attributes'] = [grouptag]
+            Palace_material['Permittivity'] = 1.0
+            if metal.is_via:
+                # anisotropic conductivity so that merged via array don't carry (much) xy current
+                xy_sigma = PEC_VIA_EQUIVALENT_CONDUCTIVITY/10
+                Palace_material['Conductivity'] = [xy_sigma, xy_sigma, PEC_VIA_EQUIVALENT_CONDUCTIVITY]
+            else:
+                Palace_material['Conductivity'] = PEC_VIA_EQUIVALENT_CONDUCTIVITY
+            Palace_materials.append(Palace_material)
+            continue
+
         material = get_material_from_layer_or_dielectric_name(layername)
 
         if material is not None:
@@ -2003,8 +2048,7 @@ def create_model (excite_ports, settings):
             Palace_material['Attributes'] = [grouptag]
             Palace_material['Permittivity'] = material.eps
 
-            metal = metals_list.getbylayername(layername)
-            if metal is not None:        
+            if metal is not None:
                 if metal.is_via:
                     # anisotropic conductivity so that merged via array don't carry (much) xy current
                     xy_sigma = material.sigma/10
@@ -2045,23 +2089,38 @@ def create_model (excite_ports, settings):
     boundaries = {}
     Palace_conductors = []
     Palace_impedances = []
+    Palace_PEC_layer_grouptags = []
 
     for item in physical_groups_2D:
         # items can be from surface of metal conductor
         internal_layername, groupname, grouptag = item.values()
         is_vertical = '_z' in internal_layername
 
-        # strip suffix _xy and _z 
+        # strip suffix _xy and _z
         layername = internal_layername.replace('_xy','')
         layername = layername.replace('_z','')
+
+        metal = metals_list.getbylayername(layername)
+
+        if metal is not None and _is_pec_material(metal.material):
+            if elmer_thermal:
+                raise _thermal_setup_error(
+                    f'Layer "{metal.name}" uses the reserved "PEC" material, which is an '
+                    'electromagnetic-only construct, not valid for thermal simulation -- assign '
+                    'a real Conductor material with ThermalConductivity for this layer instead.'
+                )
+            if metal.is_metal or metal.is_sheet:
+                # ideal conductor: goes into the Boundaries.PEC group instead of
+                # Conductivity/Impedance - merged in below with the airbox PEC faces
+                Palace_PEC_layer_grouptags.append(grouptag)
+            # metal.is_via: no boundary needed, same as a regular via lateral surface below
+            continue
 
         material = get_material_from_layer_or_dielectric_name(layername)
 
         if material is not None:
-           
-            # we also need to check metal definition
-            metal = metals_list.getbylayername(layername)
-            if metal is not None:   
+
+            if metal is not None:
 
                 # check that use of conductor or sheet matches material definition
                 if material.type == "CONDUCTOR" and metal.is_sheet:
@@ -2231,9 +2290,12 @@ def create_model (excite_ports, settings):
         Palace_absorbing_boundaries['Attributes']=[phys_group_PML] # absorbing simulation_boundary
         Palace_absorbing_boundaries['Order']=2 
 
-        # config file entry for PEC simulation boundary
+        # config file entry for PEC simulation boundary - merges the outer airbox PEC faces
+        # with any conductor/sheet layer surfaces that used the reserved "PEC" material
+        # (Palace's "Attributes" is just a list of mesh attribute IDs sharing this one
+        # boundary type, so per-layer physical groups don't need to be merged at the gmsh level)
         Palace_PEC_boundaries = {}
-        Palace_PEC_boundaries['Attributes']=[phys_group_PEC] # PEC simulation_boundary
+        Palace_PEC_boundaries['Attributes']=[phys_group_PEC] + Palace_PEC_layer_grouptags # PEC simulation_boundary
 
         # config file entry for PEC simulation boundary
         Palace_PMC_boundaries = {}
@@ -2246,7 +2308,7 @@ def create_model (excite_ports, settings):
             boundaries['Impedance']   = Palace_impedances
         if len(PML_boundaries) > 0:
             boundaries['Absorbing']   = Palace_absorbing_boundaries
-        if len(PEC_boundaries) > 0:
+        if len(PEC_boundaries) > 0 or len(Palace_PEC_layer_grouptags) > 0:
             boundaries['PEC']   = Palace_PEC_boundaries
         if len(PMC_boundaries) > 0:
             boundaries['PMC']   = Palace_PMC_boundaries
@@ -2273,6 +2335,7 @@ def create_model (excite_ports, settings):
         Elmer_materials  = []
         Elmer_bodies     = []
         Elmer_boundaries = []
+        Elmer_boundaries_PEC = []
 
         if elmer_thermal:
             # thermal sources
@@ -2281,9 +2344,31 @@ def create_model (excite_ports, settings):
 
 
         for item in physical_groups_3D:
-            # items can be from via layer or from dielectric stackup
+            # items can be from via layer, filled/solid metal volume, or dielectric stackup
 
             layername, groupname, grouptag = item.values()
+            metal = metals_list.getbylayername(layername)
+
+            if metal is not None and _is_pec_material(metal.material):
+                if elmer_thermal:
+                    raise _thermal_setup_error(
+                        f'Layer "{metal.name}" uses the reserved "PEC" material, which is an '
+                        'electromagnetic-only construct, not valid for thermal simulation -- assign '
+                        'a real Conductor material with ThermalConductivity for this layer instead.'
+                    )
+                # PEC via or filled/solid metal: Elmer has no ideal-conductor volume either,
+                # approximate with the same fixed very high conductivity domain as Palace output
+                print(f'Layer "{metal.name}" uses the reserved "PEC" material - approximated as a '
+                      f'{PEC_VIA_EQUIVALENT_CONDUCTIVITY:.0e} S/m conductivity domain, since Elmer '
+                      f'has no ideal-conductor volume.')
+                Elmer_material = {'name': PEC_MATERIAL_NAME, 'permittivity': 1.0,
+                                   'conductivity': PEC_VIA_EQUIVALENT_CONDUCTIVITY}
+                if Elmer_material not in Elmer_materials:
+                    Elmer_materials.append(Elmer_material)
+                material_index = Elmer_materials.index(Elmer_material)
+                Elmer_bodies.append({'name': layername, 'material': material_index+1})
+                continue
+
             material = get_material_from_layer_or_dielectric_name(layername)
 
             if (material is not None) or (layername == 'airbox'):
@@ -2363,19 +2448,33 @@ def create_model (excite_ports, settings):
             internal_layername, groupname, grouptag = item.values()
             is_vertical = '_z' in internal_layername
 
-            # strip suffix _xy and _z 
+            # strip suffix _xy and _z
             layername = internal_layername.replace('_xy','')
             layername = layername.replace('_z','')
+
+            metal = metals_list.getbylayername(layername)
+
+            if metal is not None and _is_pec_material(metal.material):
+                if elmer_thermal:
+                    raise _thermal_setup_error(
+                        f'Layer "{metal.name}" uses the reserved "PEC" material, which is an '
+                        'electromagnetic-only construct, not valid for thermal simulation -- assign '
+                        'a real Conductor material with ThermalConductivity for this layer instead.'
+                    )
+                if metal.is_metal or metal.is_sheet:
+                    # ideal conductor: literal PEC boundary, same "E re/im {e} = Real 0"
+                    # construct already used for the outer airbox faces
+                    Elmer_boundaries_PEC.append(gmsh.model.getPhysicalName(2, grouptag))
+                # metal.is_via: no boundary needed, same as a regular via lateral surface below
+                continue
 
             material = get_material_from_layer_or_dielectric_name(layername)
 
             if not elmer_thermal:
                 #regular RF EM
                 if material is not None:
-                
-                    # we also need to check metal definition
-                    metal = metals_list.getbylayername(layername)
-                    if metal is not None:   
+
+                    if metal is not None:
 
                         if metal.is_metal:
                             # regular metal
@@ -2466,6 +2565,7 @@ def create_model (excite_ports, settings):
                                                     Elmer_materials,
                                                     Elmer_bodies,
                                                     Elmer_boundaries,
+                                                    Elmer_boundaries_PEC,
                                                     Elmer_ports,
                                                     PEC_boundaries,
                                                     PML_boundaries,

--- a/workflow/gds2palace/util_simulation_setup.py
+++ b/workflow/gds2palace/util_simulation_setup.py
@@ -1229,6 +1229,8 @@ def create_model (excite_ports, settings):
     refined_cellsize = settings['refined_cellsize']  # mesh cell size in conductor region
     meshsize_max = get_optional_setting (settings, "meshsize_max", 70)
     adaptive_mesh_iterations = get_optional_setting (settings, "adaptive_mesh_iterations", 0)
+    amr_tol = get_optional_setting (settings, "amr_tol", 1e-2)  # AMR goal: relative error tolerance
+    amr_max_dof = get_optional_setting (settings, "amr_max_dof", 2e6)  # AMR maximum number of unknowns
     save_adaptive_mesh = get_optional_setting (settings, "save_adaptive_mesh", False)
     save_gmsh_geometry =  get_optional_setting (settings, "save_gmsh_unrolled", False)
     substrate_refinement = get_optional_setting (settings, "substrate_refinement", False)
@@ -1906,12 +1908,12 @@ def create_model (excite_ports, settings):
     # model shows the fixed per-invocation overhead becoming a small fraction of total time.
     Refinement = {
         "UniformLevels": 0,
-        "Tol": 1e-2,
+        "Tol": amr_tol,
         "MaxIts": adaptive_mesh_iterations,
-        "MaxSize": 2e6,
+        "MaxSize": amr_max_dof,
         "Nonconformal": True,
         "UpdateFraction": 0.7,
-        "SaveAdaptMesh": save_adaptive_mesh        	
+        "SaveAdaptMesh": save_adaptive_mesh
     }
 
     model =  {

--- a/workflow/gds2palace/util_stackup_reader.py
+++ b/workflow/gds2palace/util_stackup_reader.py
@@ -48,8 +48,16 @@
 #              so a caller built before <Variables> existed (e.g. setupEM's stackup_editor.py,
 #              which constructs these directly rather than via parse_substrate()) keeps working
 #              unchanged for ordinary files, instead of every call raising TypeError outright
+# 12 Sep 2026: added a built-in default "AIR" material (Permittivity=1.0, matching the
+#              convention already used across example stackup files) so a <Dielectric>/<Layer>
+#              can reference Material="AIR" without a <Material Name="AIR"> entry in the file;
+#              an explicit user-defined <Material Name="AIR"> still overrides it
+# 12 Sep 2026: added the reserved "PEC" material name - Layer Material="PEC" is now valid on
+#              conductor/via/sheet layers without any matching <Materials> entry; see
+#              get_material_from_layer_or_dielectric_name() in util_simulation_setup.py for
+#              where the reserved name is resolved into each solver's ideal-conductor construct
 
-__version__ = "1.7.2"
+__version__ = "1.8.0"
 
 import os
 import math
@@ -64,6 +72,24 @@ import xml.etree.ElementTree
 # change actually needs a newer reader to be interpreted correctly (e.g. Reference/
 # ReferenceEdge bumped the format to "3.0"; <Variables>/"=" expressions bumped it to "3.1").
 SUPPORTED_SCHEMA_VERSION = "3.1"
+
+# Reserved Layer Material="..." name for an ideal conductor. Recognized case-insensitively
+# directly on metal_layer.material by util_simulation_setup.py/util_elmer.py, bypassing
+# stackup_materials_list.get_by_name() entirely - it is valid on a conductor/via/sheet layer
+# with no matching <Material> entry in <Materials> at all.
+PEC_MATERIAL_NAME = "PEC"
+
+# Built-in default properties for the reserved "AIR" dielectric material, used by
+# parse_substrate() below only when the file doesn't define its own <Material Name="AIR">.
+# Matches the convention already used consistently across existing example stackup files.
+DEFAULT_AIR_MATERIAL_ATTRIBUTES = {
+    "Name": "AIR",
+    "Type": "Dielectric",
+    "Permittivity": "1.0",
+    "DielectricLossTangent": "0.0",
+    "Conductivity": "0",
+    "Color": "d0d0d0",
+}
 
 
 def _parse_schema_version (version_string):
@@ -1514,6 +1540,13 @@ def parse_substrate (substrate_root, variable_overrides=None):
   materials_list = stackup_materials_list() # initialize empty list
   for data in  substrate_root.iter("Material"):
       materials_list.append (stackup_material(data, variables))
+
+  # provide "AIR" as a built-in default dielectric material (e.g. for an air-gap Dielectric/
+  # Layer) if the file doesn't define its own <Material Name="AIR"> - runs after the loop
+  # above, so a user-defined AIR (in any case) already resolves via get_by_name() and wins
+  if materials_list.get_by_name("AIR") is None:
+      default_air_data = xml.etree.ElementTree.Element("Material", DEFAULT_AIR_MATERIAL_ATTRIBUTES)
+      materials_list.append (stackup_material(default_air_data, variables))
 
   # get dielectric layers from  XML
   dielectrics_list = dielectric_layers_list() # initialize empty list


### PR DESCRIPTION
## Summary
- Make AMR goal (`Tol`) and maximum DOF (`MaxSize`) configurable settings (`amr_tol`, `amr_max_dof`), defaulting to the previous hardcoded values, so setupEM can surface them as user-configurable fields
- Add reserved stackup materials needing no `<Materials>` entry: `Material="PEC"` (ideal conductor on conductor/via/sheet Layers — Palace `Boundaries.PEC` / Elmer's zero-tangential-E boundary for conductors/sheets, a high-conductivity domain approximation for vias) and a built-in default `"AIR"` dielectric (overridable by an explicit `<Material Name="AIR">`)
- Using `PEC` together with Elmer thermal output now raises a clear error instead of silently doing the wrong thing
- Bump version to 0.5.0

## Test plan
- [x] Verified PEC/AIR end-to-end through real gmsh meshing and Palace JSON/Elmer SIF generation on modified example stackups (sheet, metal, and via layers; Elmer output; thermal-mode rejection)
- [x] Verified AIR default injection and user-override precedence via direct `parse_substrate()` calls
- [x] Syntax-checked all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)